### PR TITLE
Fix endian helpers for ESP builds

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -6,10 +6,10 @@
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
-#include "sha256.h"
 #ifdef ESP_PLATFORM
 #include "port/esp32s3/port_config.hpp"
 #endif
+#include "sha256.h"
 
 // big endian architectures need #define __BYTE_ORDER __BIG_ENDIAN
 #ifndef _MSC_VER

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -3,6 +3,10 @@
 #ifndef SLAC_CHANNEL_HPP
 #define SLAC_CHANNEL_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
 #include <string>
 #include <slac/transport.hpp>
 

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -3,6 +3,10 @@
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
 #include <cstdint>
 #include <utility>
 

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -1,6 +1,10 @@
 #ifndef SLAC_TRANSPORT_HPP
 #define SLAC_TRANSPORT_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
 #include <cstdint>
 #include <cstddef>
 

--- a/port/esp32s3/ethernet_defs.hpp
+++ b/port/esp32s3/ethernet_defs.hpp
@@ -1,6 +1,10 @@
 #ifndef SLAC_ETHERNET_DEFS_HPP
 #define SLAC_ETHERNET_DEFS_HPP
 
+#ifdef ESP_PLATFORM
+#include "port_config.hpp"
+#endif
+
 #include <stdint.h>
 
 #define ETH_ALEN 6

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -1,14 +1,13 @@
 #ifndef SLAC_PORT_CONFIG_HPP
 #define SLAC_PORT_CONFIG_HPP
 
-#include <endian.h>
 #include <stdint.h>
 
 #ifdef ESP_PLATFORM
-#  define le16toh(x) (x)
-#  define htole16(x) (x)
-#  define le32toh(x) (x)
-#  define htole32(x) (x)
+static inline uint16_t le16toh(uint16_t v) { return v; }
+static inline uint16_t htole16(uint16_t v) { return v; }
+static inline uint32_t le32toh(uint32_t v) { return v; }
+static inline uint32_t htole32(uint32_t v) { return v; }
 #endif
 
 #endif // SLAC_PORT_CONFIG_HPP

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1,23 +1,11 @@
+#ifdef ESP_PLATFORM
+#include "port_config.hpp"
+#endif
 #include "qca7000.hpp"
 #include <esp_log.h>
 
 const char* PLC_TAG = "PLC_IF";
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-static inline uint16_t htole16(uint16_t v) {
-    return v;
-}
-static inline uint16_t le16toh(uint16_t v) {
-    return v;
-}
-#else
-static inline uint16_t htole16(uint16_t v) {
-    return (v >> 8) | (v << 8);
-}
-static inline uint16_t le16toh(uint16_t v) {
-    return (v >> 8) | (v << 8);
-}
-#endif
 
 uint8_t myethtransmitbuffer[V2GTP_BUFFER_SIZE]{};
 size_t myethtransmitlen = 0;

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifdef ESP_PLATFORM
+#include "port_config.hpp"
+#endif
+
 #include "ethernet_defs.hpp"
 #include <Arduino.h>
 #include <SPI.h>

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -1,9 +1,8 @@
-#include "qca7000_link.hpp"
-#include "qca7000.hpp"
-
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
 #endif
+#include "qca7000_link.hpp"
+#include "qca7000.hpp"
 
 namespace slac {
 namespace port {

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -1,6 +1,10 @@
 #ifndef SLAC_QCA7000_LINK_HPP
 #define SLAC_QCA7000_LINK_HPP
 
+#ifdef ESP_PLATFORM
+#include "port_config.hpp"
+#endif
+
 #include <slac/transport.hpp>
 
 namespace slac {


### PR DESCRIPTION
## Summary
- define byte-order helpers in `port_config.hpp`
- include `port_config.hpp` ahead of system headers
- clean up redundant endian helpers in `qca7000.cpp`

## Testing
- `cmake -S . -B build` *(fails: Could not find package `everest-cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_6880f3325c04832495482d222b473dbd