### PR TITLE
Add port_config include across headers

### DIFF
--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -3,6 +3,11 @@
 #ifndef SLAC_CHANNEL_HPP
 #define SLAC_CHANNEL_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <string>
 #include <slac/transport.hpp>
 

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -3,6 +3,11 @@
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <cstdint>
 #include <utility>
 

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -1,6 +1,11 @@
 #ifndef SLAC_TRANSPORT_HPP
 #define SLAC_TRANSPORT_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <cstdint>
 #include <cstddef>
 

--- a/port/esp32s3/endian_compat.hpp
+++ b/port/esp32s3/endian_compat.hpp
@@ -1,6 +1,11 @@
 #ifndef SLAC_ENDIAN_COMPAT_HPP
 #define SLAC_ENDIAN_COMPAT_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <stdint.h>
 
 inline uint16_t htons(uint16_t x) { return (x << 8) | (x >> 8); }

--- a/port/esp32s3/ethernet_defs.hpp
+++ b/port/esp32s3/ethernet_defs.hpp
@@ -1,6 +1,11 @@
 #ifndef SLAC_ETHERNET_DEFS_HPP
 #define SLAC_ETHERNET_DEFS_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <stdint.h>
 
 #define ETH_ALEN 6

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -1,5 +1,10 @@
 #pragma once
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include "ethernet_defs.hpp"
 #include <Arduino.h>
 #include <SPI.h>

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -1,6 +1,11 @@
 #ifndef SLAC_QCA7000_LINK_HPP
 #define SLAC_QCA7000_LINK_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <slac/transport.hpp>
 
 namespace slac {

--- a/src/packet_socket.hpp
+++ b/src/packet_socket.hpp
@@ -3,6 +3,11 @@
 #ifndef SRC_PACKET_SOCKET_HPP
 #define SRC_PACKET_SOCKET_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <cstdint>
 #include <string>
 

--- a/tools/evse/evse_fsm.hpp
+++ b/tools/evse/evse_fsm.hpp
@@ -3,6 +3,11 @@
 #ifndef EVSE_FSM_HPP
 #define EVSE_FSM_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <chrono>
 #include <string>
 

--- a/tools/evse/slac_io.hpp
+++ b/tools/evse/slac_io.hpp
@@ -3,6 +3,11 @@
 #ifndef SLAC_IO_HPP
 #define SLAC_IO_HPP
 
+#ifdef ESP_PLATFORM
+#include "port/esp32s3/port_config.hpp"
+#endif
+
+
 #include <condition_variable>
 #include <functional>
 #include <mutex>


### PR DESCRIPTION
## Summary
- include the ESP port configuration in header files so macros are available

## Testing
- `cmake .. -DBUILD_TESTING=ON -DCMAKE_PREFIX_PATH=$(pwd)/../everest-cmake -DDISABLE_EDM=ON` *(fails: missing gtest main during linking)*

------
https://chatgpt.com/codex/tasks/task_e_6880f687cf788324bf7d9abe11e97603