### PR TITLE
Fix header resolution for non-POSIX platforms

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -15,6 +15,12 @@
 #ifndef _MSC_VER
 #if defined(ESP_PLATFORM) && !defined(__GLIBC__)
 #include "port/esp32s3/endian_compat.hpp"
+#elif defined(__has_include)
+#  if __has_include(<endian.h>)
+#    include <endian.h>
+#  else
+#    include "port/esp32s3/endian_compat.hpp"
+#  endif
 #else
 #include <endian.h>
 #endif

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -12,6 +12,12 @@
 
 #if defined(ESP_PLATFORM)
 #include "port/esp32s3/ethernet_defs.hpp"
+#elif defined(__has_include)
+#  if __has_include(<net/ethernet.h>)
+#    include <net/ethernet.h>
+#  else
+#    include "port/esp32s3/ethernet_defs.hpp"
+#  endif
 #else
 #include <net/ethernet.h>
 #endif


### PR DESCRIPTION
## Summary
- use `__has_include` in slac.hpp so builds without `<net/ethernet.h>` fall back to internal definitions
- improve SHA256 endian header detection to avoid missing `<endian.h>`

## Testing
- `cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release` *(fails: could not find package `everest-cmake`)*

------
https://chatgpt.com/codex/tasks/task_e_6881072bd5d4832488c2a7b226a170d5