### PR TITLE
Refactor CMake to drop everest-cmake macros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,16 @@ project(slac VERSION 0.3.1
 		LANGUAGES CXX C
 )
 
-find_package(everest-cmake 0.1 REQUIRED
-    PATHS ../everest-cmake
-)
+include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
 
 # options
 option(BUILD_SLAC_TOOLS "Build SLAC tools" OFF)
-option(SLAC_INSTALL "Install the library (shared data might be installed anyway)" ${EVC_MAIN_PROJECT})
+set(SLAC_INSTALL_DEFAULT OFF)
+if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  set(SLAC_INSTALL_DEFAULT ON)
+endif()
+option(SLAC_INSTALL "Install the library (shared data might be installed anyway)" ${SLAC_INSTALL_DEFAULT})
 option(${PROJECT_NAME}_BUILD_TESTING "Build unit tests, used if included as dependency" OFF)
 option(BUILD_TESTING "Build unit tests, used if standalone project" OFF)
 
@@ -21,9 +24,6 @@ if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TEST
     add_subdirectory(tests)
 endif()
 
-if(NOT DISABLE_EDM)
-    evc_setup_edm()
-endif()
 
 add_subdirectory(3rd_party)
 
@@ -55,20 +55,35 @@ if (BUILD_SLAC_TOOLS)
     add_subdirectory(tools)
 endif()
 
+
 if (SLAC_INSTALL)
-    install(
-        TARGETS slac
-        EXPORT slac-targets
-    )
+    install(TARGETS slac
+            EXPORT slac-targets
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
-    install(
-        DIRECTORY include/
-        TYPE INCLUDE
-    )
+    install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
-    evc_setup_package(
-        NAME slac
-        NAMESPACE slac
-        EXPORT slac-targets
-    )
+    install(EXPORT slac-targets
+            NAMESPACE slac::
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/slac)
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/slac-config-version.cmake
+        VERSION ${PROJECT_VERSION}
+        COMPATIBILITY SameMajorVersion)
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_LIST_DIR}/cmake/slac-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/slac-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/slac)
+
+    install(FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/slac-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/slac-config-version.cmake
+            DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/slac)
 endif()
+
+export(TARGETS slac NAMESPACE slac:: FILE ${CMAKE_CURRENT_BINARY_DIR}/slac-targets.cmake)
+

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Clone the repository and its submodules:
 Building with CMake
 -------------------
 
-The project uses ``CMake``. A recent CMake (>= 3.11) installation is required. The ``everest-cmake`` helper repository is used for common build settings and dependency management.
+The project uses ``CMake`` (>= 3.11) and standard commands for dependency management.
 
 A typical build looks as follows:
 

--- a/cmake/slac-config.cmake.in
+++ b/cmake/slac-config.cmake.in
@@ -1,0 +1,2 @@
+@PACKAGE_INIT@
+include("${CMAKE_CURRENT_LIST_DIR}/slac-targets.cmake")


### PR DESCRIPTION
## Summary
- remove everest-cmake from build
- set up install rules with standard CMake
- generate and install config files
- update README accordingly

## Testing
- `cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build`
- `cmake --install build --prefix /tmp/install`


------
https://chatgpt.com/codex/tasks/task_e_6881261aa1b88324bfd5a2ca6a263d7f