### PR TITLE
Fix SlacIO transport initialization

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,6 +79,7 @@ A minimal example can be found in ``pio_src/main.cpp``:
 
    slac::transport::Link* link = nullptr; // provide your implementation
    slac::Channel channel(link);
+   channel.open();
    // send/receive messages using channel.read() and channel.write()
 
 Tools and Examples

--- a/pio_src/main.cpp
+++ b/pio_src/main.cpp
@@ -10,6 +10,7 @@ static slac::Channel* channel = nullptr;
 
 void setup() {
     channel = new slac::Channel(g_link);
+    channel->open();
 }
 
 void loop() {
@@ -19,6 +20,7 @@ void loop() {
 int main() {
     slac::transport::Link* link = nullptr; // placeholder
     slac::Channel ch(link);
+    ch.open();
     return 0;
 }
 #endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,16 +1,12 @@
 add_executable(${PROJECT_NAME}_unit_test libslac_unit_test.cpp)
 
-target_include_directories(${PROJECT_NAME}_unit_test PUBLIC${GTEST_INCLUDE_DIRS})
+find_package(GTest REQUIRED)
+target_include_directories(${PROJECT_NAME}_unit_test PUBLIC ${GTEST_INCLUDE_DIRS})
 
-
-if(DISABLE_EDM)
-    find_package(GTest REQUIRED)
-else()
-    set(GTEST_LIBRARIES
-        GTest::gtest
-        GTest::gtest_main
-    )
-endif()
+set(GTEST_LIBRARIES
+    GTest::gtest
+    GTest::gtest_main
+)
 
 target_link_libraries(${PROJECT_NAME}_unit_test PRIVATE
         ${GTEST_LIBRARIES}

--- a/tools/evse/CMakeLists.txt
+++ b/tools/evse/CMakeLists.txt
@@ -4,6 +4,7 @@ add_executable(evse
     evse.cpp
     evse_fsm.cpp
     slac_io.cpp
+    packet_socket_link.cpp
 )
 
 target_link_libraries(evse PRIVATE

--- a/tools/evse/packet_socket_link.cpp
+++ b/tools/evse/packet_socket_link.cpp
@@ -1,0 +1,40 @@
+#include "packet_socket_link.hpp"
+
+PacketSocketLink::PacketSocketLink(const std::string& if_name) : if_name(if_name) {
+}
+
+bool PacketSocketLink::open() {
+    if_info = std::make_unique<utils::InterfaceInfo>(if_name);
+    if (!if_info->is_valid()) {
+        return false;
+    }
+    socket = std::make_unique<utils::PacketSocket>(*if_info, slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    return socket->is_valid();
+}
+
+bool PacketSocketLink::write(const uint8_t* buf, size_t len, uint32_t timeout_ms) {
+    if (!socket)
+        return false;
+    return socket->write(buf, len, timeout_ms) == utils::PacketSocket::IOResult::Ok;
+}
+
+bool PacketSocketLink::read(uint8_t* buf, size_t len, size_t* out_len, uint32_t timeout_ms) {
+    if (!socket) {
+        *out_len = 0;
+        return false;
+    }
+    auto res = socket->read(buf, timeout_ms);
+    if (res == utils::PacketSocket::IOResult::Ok) {
+        *out_len = socket->get_last_read_size();
+        return true;
+    }
+    *out_len = 0;
+    return false;
+}
+
+const uint8_t* PacketSocketLink::mac() const {
+    if (!if_info)
+        return nullptr;
+    return if_info->get_mac();
+}
+

--- a/tools/evse/packet_socket_link.hpp
+++ b/tools/evse/packet_socket_link.hpp
@@ -1,0 +1,22 @@
+#ifndef PACKET_SOCKET_LINK_HPP
+#define PACKET_SOCKET_LINK_HPP
+
+#include <memory>
+#include <slac/transport.hpp>
+#include "../../src/packet_socket.hpp"
+
+class PacketSocketLink : public slac::transport::Link {
+public:
+    explicit PacketSocketLink(const std::string& if_name);
+    bool open() override;
+    bool write(const uint8_t* buf, size_t len, uint32_t timeout_ms) override;
+    bool read(uint8_t* buf, size_t len, size_t* out_len, uint32_t timeout_ms) override;
+    const uint8_t* mac() const override;
+
+private:
+    std::string if_name;
+    std::unique_ptr<utils::InterfaceInfo> if_info;
+    std::unique_ptr<utils::PacketSocket> socket;
+};
+
+#endif // PACKET_SOCKET_LINK_HPP

--- a/tools/evse/slac_io.cpp
+++ b/tools/evse/slac_io.cpp
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include "slac_io.hpp"
+#include "packet_socket_link.hpp"
 
 #include <stdexcept>
 #include <thread>
 
-SlacIO::SlacIO(const std::string& if_name) {
-    if (!slac_channel.open(if_name)) {
+SlacIO::SlacIO(const std::string& if_name)
+    : link(std::make_unique<PacketSocketLink>(if_name)), slac_channel(link.get()) {
+    if (!slac_channel.open()) {
         throw std::runtime_error(slac_channel.get_error());
     }
 }

--- a/tools/evse/slac_io.hpp
+++ b/tools/evse/slac_io.hpp
@@ -6,6 +6,7 @@
 #include <condition_variable>
 #include <functional>
 #include <mutex>
+#include <memory>
 #include <string>
 #include <thread>
 
@@ -23,6 +24,7 @@ public:
 
 private:
     void loop();
+    std::unique_ptr<slac::transport::Link> link;
     slac::Channel slac_channel;
     slac::messages::HomeplugMessage incoming_msg;
     std::function<InputHandlerFnType> input_handler;


### PR DESCRIPTION
## Summary
- create PacketSocketLink implementing `transport::Link`
- construct `slac::Channel` with this link and call `open()`
- update minimal examples and docs to call `channel.open()`
- build helper in toolchain
- fix tests CMake to always find GTest

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68812898de108324ac98c3373c69e082