### PR TITLE
Add optional SlacIO threading & ESP support

### DIFF
--- a/include/slac/packet_socket.hpp
+++ b/include/slac/packet_socket.hpp
@@ -6,7 +6,9 @@
 #include <cstdint>
 #include <string>
 
+#ifndef ESP_PLATFORM
 #include <linux/if_ether.h>
+#endif
 
 namespace utils {
 class InterfaceInfo {

--- a/src/packet_socket.cpp
+++ b/src/packet_socket.cpp
@@ -4,6 +4,7 @@
 
 #include <cstring>
 
+#ifndef ESP_PLATFORM
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <linux/if_packet.h>
@@ -11,6 +12,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#endif
 
 namespace utils {
 InterfaceInfo::InterfaceInfo(const std::string& interface_name) {

--- a/src/packet_socket_link.cpp
+++ b/src/packet_socket_link.cpp
@@ -1,6 +1,8 @@
 #include <slac/packet_socket_link.hpp>
 
+#ifndef ESP_PLATFORM
 #include <linux/if_ether.h>
+#endif
 #include <memory>
 #include <cstring>
 #include <slac/slac.hpp>


### PR DESCRIPTION
## Summary
- make `SlacIO` background thread optional and document the API
- add FreeRTOS task based implementation for ESP builds
- guard POSIX specific includes

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68812ea96a0c8324b91c39d2847dd72c