### PR TITLE
Improve QCA7000 configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,6 +82,22 @@ A minimal example can be found in ``pio_src/main.cpp``:
    channel.open();
    // send/receive messages using channel.read() and channel.write()
 
+QCA7000 Configuration
+---------------------
+
+The SPI pins used to communicate with the QCA7000 modem are defined in
+``port/esp32s3/qca7000.hpp`` as ``PLC_SPI_CS_PIN`` and ``PLC_SPI_RST_PIN``.
+Override these macros when building to match your hardware wiring.
+
+The modem's MAC address can be specified via ``qca7000_config`` when
+creating :class:`slac::port::Qca7000Link`:
+
+.. code-block:: cpp
+
+   const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+   qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+   slac::port::Qca7000Link link(cfg);
+
 Tools and Examples
 ------------------
 

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -17,36 +17,36 @@
 #define V2GTP_BUFFER_SIZE 1536
 #endif
 
-// Placeholder register and interrupt definitions for building the library
+// Register and interrupt definitions (see QCA7000 datasheet)
 #ifndef SPI_INT_CPU_ON
-#define SPI_INT_CPU_ON 0x0001
+#define SPI_INT_CPU_ON 0x0040
 #endif
 #ifndef SPI_INT_PKT_AVLBL
-#define SPI_INT_PKT_AVLBL 0x0002
+#define SPI_INT_PKT_AVLBL 0x0001
 #endif
 #ifndef SPI_INT_RDBUF_ERR
-#define SPI_INT_RDBUF_ERR 0x0004
+#define SPI_INT_RDBUF_ERR 0x0002
 #endif
 #ifndef SPI_INT_WRBUF_ERR
-#define SPI_INT_WRBUF_ERR 0x0008
+#define SPI_INT_WRBUF_ERR 0x0004
 #endif
 #ifndef SPI_REG_SIGNATURE
-#define SPI_REG_SIGNATURE 0x0000
+#define SPI_REG_SIGNATURE 0x1A00
 #endif
 #ifndef SPI_REG_WRBUF_SPC_AVA
-#define SPI_REG_WRBUF_SPC_AVA 0x0000
+#define SPI_REG_WRBUF_SPC_AVA 0x0200
 #endif
 #ifndef SPI_REG_INTR_CAUSE
-#define SPI_REG_INTR_CAUSE 0x0000
+#define SPI_REG_INTR_CAUSE 0x0C00
 #endif
 #ifndef SPI_REG_BFR_SIZE
-#define SPI_REG_BFR_SIZE 0x0000
+#define SPI_REG_BFR_SIZE 0x0100
 #endif
 #ifndef SPI_REG_RDBUF_BYTE_AVA
-#define SPI_REG_RDBUF_BYTE_AVA 0x0000
+#define SPI_REG_RDBUF_BYTE_AVA 0x0300
 #endif
 #ifndef SPI_REG_INTR_ENABLE
-#define SPI_REG_INTR_ENABLE 0x0000
+#define SPI_REG_INTR_ENABLE 0x0D00
 #endif
 
 #ifndef PLC_SPI_RST_PIN
@@ -59,6 +59,7 @@
 struct qca7000_config {
     SPIClass* spi;
     int cs_pin;
+    const uint8_t* mac_addr{nullptr};
 };
 
 bool qca7000setup(SPIClass* spi, int cs_pin);

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -7,7 +7,7 @@
 namespace slac {
 namespace port {
 
-Qca7000Link::Qca7000Link() {
+Qca7000Link::Qca7000Link(const qca7000_config& c) : cfg(c) {
     memset(mac_addr, 0, sizeof(mac_addr));
 }
 
@@ -15,12 +15,18 @@ bool Qca7000Link::open() {
     if (initialized)
         return true;
 
-    if (!qca7000setup(&SPI, /*CS*/ PLC_SPI_CS_PIN))
+    SPIClass* bus = cfg.spi ? cfg.spi : &SPI;
+    int cs = cfg.cs_pin ? cfg.cs_pin : PLC_SPI_CS_PIN;
+
+    if (!qca7000setup(bus, cs))
         return false;
 
-    // use a fixed MAC address for now
-    const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-    memcpy(mac_addr, def_mac, ETH_ALEN);
+    if (cfg.mac_addr)
+        memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);
+    else {
+        const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+        memcpy(mac_addr, def_mac, ETH_ALEN);
+    }
     initialized = true;
     return true;
 }

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -13,7 +13,7 @@ namespace port {
 
 class Qca7000Link : public transport::Link {
 public:
-    Qca7000Link();
+    explicit Qca7000Link(const qca7000_config& cfg);
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
@@ -22,6 +22,7 @@ public:
 
 private:
     bool initialized{false};
+    qca7000_config cfg;
     uint8_t mac_addr[ETH_ALEN]{};
 };
 


### PR DESCRIPTION
## Summary
- define QCA7000 register and interrupt constants
- extend `qca7000_config` and link implementation to allow custom MAC address
- document how to configure the SPI pins and MAC address

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6881333995448324abbc57a6b221f9bb