### PR TITLE
Update QCA7000 driver configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,24 @@ Tools and Examples
 
 The ``tools`` directory contains small utilities demonstrating how to use ``libslac``. ``tools/bridge.cpp`` shows how to forward packets between two virtual interfaces. The ``tools/evse`` directory contains a simple state machine for the EVSE side of the SLAC handshake.
 
+Configuring the QCA7000 Driver
+------------------------------
+
+The ESP32 port provides a lightweight driver for the QCA7000 PLC modem. SPI and
+reset pins can be configured via the ``PLC_SPI_CS_PIN`` and ``PLC_SPI_RST_PIN``
+macros. ``Qca7000Link`` accepts a :cpp:struct:`qca7000_config` allowing to pass
+the SPI bus, chip select and the desired MAC address:
+
+.. code-block:: cpp
+
+   slac::port::qca7000_config cfg;
+   cfg.spi = &SPI;            // SPI bus used by the modem
+   cfg.cs_pin = 5;            // chip select pin
+   cfg.mac[0] = 0x02;         // choose a unique MAC
+
+   slac::port::Qca7000Link link(cfg);
+   link.open();
+
 Running the Tests
 -----------------
 

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -17,36 +17,45 @@
 #define V2GTP_BUFFER_SIZE 1536
 #endif
 
-// Placeholder register and interrupt definitions for building the library
-#ifndef SPI_INT_CPU_ON
-#define SPI_INT_CPU_ON 0x0001
-#endif
+// QCA7000 register definitions from datasheet
 #ifndef SPI_INT_PKT_AVLBL
-#define SPI_INT_PKT_AVLBL 0x0002
+#define SPI_INT_PKT_AVLBL 0x0001
 #endif
 #ifndef SPI_INT_RDBUF_ERR
-#define SPI_INT_RDBUF_ERR 0x0004
+#define SPI_INT_RDBUF_ERR 0x0002
 #endif
 #ifndef SPI_INT_WRBUF_ERR
-#define SPI_INT_WRBUF_ERR 0x0008
+#define SPI_INT_WRBUF_ERR 0x0004
 #endif
-#ifndef SPI_REG_SIGNATURE
-#define SPI_REG_SIGNATURE 0x0000
+#ifndef SPI_INT_ADDR_ERR
+#define SPI_INT_ADDR_ERR 0x0008
 #endif
-#ifndef SPI_REG_WRBUF_SPC_AVA
-#define SPI_REG_WRBUF_SPC_AVA 0x0000
+#ifndef SPI_INT_CPU_ON
+#define SPI_INT_CPU_ON 0x0040
 #endif
-#ifndef SPI_REG_INTR_CAUSE
-#define SPI_REG_INTR_CAUSE 0x0000
+#ifndef SPI_INT_WRBUF_BELOW_WM
+#define SPI_INT_WRBUF_BELOW_WM 0x0400
 #endif
 #ifndef SPI_REG_BFR_SIZE
-#define SPI_REG_BFR_SIZE 0x0000
+#define SPI_REG_BFR_SIZE 0x0100
+#endif
+#ifndef SPI_REG_WRBUF_SPC_AVA
+#define SPI_REG_WRBUF_SPC_AVA 0x0200
 #endif
 #ifndef SPI_REG_RDBUF_BYTE_AVA
-#define SPI_REG_RDBUF_BYTE_AVA 0x0000
+#define SPI_REG_RDBUF_BYTE_AVA 0x0300
+#endif
+#ifndef SPI_REG_INTR_CAUSE
+#define SPI_REG_INTR_CAUSE 0x0C00
 #endif
 #ifndef SPI_REG_INTR_ENABLE
-#define SPI_REG_INTR_ENABLE 0x0000
+#define SPI_REG_INTR_ENABLE 0x0D00
+#endif
+#ifndef SPI_REG_SIGNATURE
+#define SPI_REG_SIGNATURE 0x1A00
+#endif
+#ifndef SPI_REG_ACTION_CTRL
+#define SPI_REG_ACTION_CTRL 0x1B00
 #endif
 
 #ifndef PLC_SPI_RST_PIN
@@ -57,8 +66,9 @@
 #endif
 
 struct qca7000_config {
-    SPIClass* spi;
-    int cs_pin;
+    SPIClass* spi{&SPI};
+    int cs_pin{PLC_SPI_CS_PIN};
+    uint8_t mac[ETH_ALEN]{0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
 };
 
 bool qca7000setup(SPIClass* spi, int cs_pin);

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -7,20 +7,18 @@
 namespace slac {
 namespace port {
 
-Qca7000Link::Qca7000Link() {
-    memset(mac_addr, 0, sizeof(mac_addr));
+Qca7000Link::Qca7000Link(const qca7000_config& cfg) : cfg_(cfg) {
+    memcpy(mac_addr, cfg_.mac, ETH_ALEN);
 }
 
 bool Qca7000Link::open() {
     if (initialized)
         return true;
 
-    if (!qca7000setup(&SPI, /*CS*/ PLC_SPI_CS_PIN))
+    if (!qca7000setup(cfg_.spi, cfg_.cs_pin))
         return false;
 
-    // use a fixed MAC address for now
-    const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-    memcpy(mac_addr, def_mac, ETH_ALEN);
+    memcpy(mac_addr, cfg_.mac, ETH_ALEN);
     initialized = true;
     return true;
 }

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -13,7 +13,7 @@ namespace port {
 
 class Qca7000Link : public transport::Link {
 public:
-    Qca7000Link();
+    explicit Qca7000Link(const qca7000_config& cfg = {});
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
@@ -21,6 +21,7 @@ public:
     const uint8_t* mac() const override;
 
 private:
+    qca7000_config cfg_{};
     bool initialized{false};
     uint8_t mac_addr[ETH_ALEN]{};
 };


### PR DESCRIPTION
## Summary
- implement real QCA7000 register addresses
- add configurable MAC for `Qca7000Link`
- document SPI and MAC configuration

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6881333995448324abbc57a6b221f9bb