### PR TITLE
Fix esp32s3 build and document command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,9 @@ Invoke PlatformIO using:
 
    pio run -e esp32s3
 
+This command builds the example firmware for ESP32-S3 boards and is
+useful to verify compilation after refactoring.
+
 Library Concepts
 ----------------
 

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -7,6 +7,7 @@
 
 #include <slac/transport.hpp>
 #include "ethernet_defs.hpp"
+#include "qca7000.hpp"
 
 namespace slac {
 namespace port {


### PR DESCRIPTION
## Summary
- include `qca7000.hpp` in `Qca7000Link` header so PlatformIO build works
- clarify README instructions for running the ESP32-S3 build

## Testing
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_688136cc5c008324a88c8fc5e097ff43