### PR TITLE
Make tools/tests optional for embedded builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,10 +18,17 @@ option(SLAC_INSTALL "Install the library (shared data might be installed anyway)
 option(${PROJECT_NAME}_BUILD_TESTING "Build unit tests, used if included as dependency" OFF)
 option(BUILD_TESTING "Build unit tests, used if standalone project" OFF)
 
-if((${CMAKE_PROJECT_NAME} STREQUAL ${PROJECT_NAME} OR ${PROJECT_NAME}_BUILD_TESTING) AND BUILD_TESTING)
-    set(LIBSLAC_BUILD_TESTING ON)
-    include(CTest)
-    add_subdirectory(tests)
+if(ESP_PLATFORM)
+  set(BUILD_SLAC_TOOLS OFF CACHE BOOL "Build SLAC tools" FORCE)
+  set(BUILD_TESTING OFF CACHE BOOL "Build unit tests" FORCE)
+endif()
+
+if(BUILD_TESTING)
+    if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR ${PROJECT_NAME}_BUILD_TESTING)
+        set(LIBSLAC_BUILD_TESTING ON)
+        include(CTest)
+        add_subdirectory(tests)
+    endif()
 endif()
 
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,13 +5,13 @@ src_dir = .
 platform = native
 build_flags = -Iinclude -I3rd_party
 lib_ldf_mode = off
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<src/packet_socket.cpp> +<3rd_party/hash_library/sha256.cpp> -<port/esp32s3/qca7000_link.cpp> +<pio_src/main.cpp>
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<src/packet_socket.cpp> +<src/packet_socket_link.cpp> +<3rd_party/hash_library/sha256.cpp> -<port/esp32s3/qca7000_link.cpp>
 
 [env:esp32s3]
 platform = espressif32@6.5.0
 board = esp32-s3-devkitc-1
 framework = arduino
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -Iinclude -I3rd_party -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti
+build_flags = -std=gnu++17 -Iinclude -I3rd_party -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp>


### PR DESCRIPTION
## Summary
- gate tests with `BUILD_TESTING`
- disable building tools/tests when `ESP_PLATFORM` is set
- adjust PlatformIO configs to compile only core sources

## Testing
- `cmake -B build -S . -G Ninja`
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_688136c2a1cc83249594f1eb74022304