### PR TITLE
Store message length from Link reads

### DIFF
--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -172,6 +172,8 @@ public:
         return raw_msg_len;
     }
 
+    void set_raw_msg_len(int len);
+
     void setup_payload(void const* payload, int len, uint16_t mmtype, const defs::MMV mmv);
     void setup_ethernet_header(const uint8_t dst_mac_addr[ETH_ALEN], const uint8_t src_mac_addr[ETH_ALEN] = nullptr);
 

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -39,7 +39,7 @@ bool Channel::read(slac::messages::HomeplugMessage& msg, int timeout) {
     bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()), sizeof(messages::homeplug_message),
                          &out_len, timeout);
     if (ok) {
-        (void)out_len; // TODO handle length
+        msg.set_raw_msg_len(static_cast<int>(out_len));
         return true;
     }
     return false;
@@ -54,7 +54,7 @@ bool Channel::poll(slac::messages::HomeplugMessage& msg) {
     bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()), sizeof(messages::homeplug_message),
                          &out_len, 0);
     if (ok) {
-        (void)out_len;
+        msg.set_raw_msg_len(static_cast<int>(out_len));
         return true;
     }
     return false;

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -140,6 +140,10 @@ uint8_t* HomeplugMessage::get_src_mac() {
     return raw_msg.ethernet_header.ether_shost;
 }
 
+void HomeplugMessage::set_raw_msg_len(int len) {
+    raw_msg_len = len;
+}
+
 bool HomeplugMessage::is_valid() const {
     return raw_msg_len >= defs::MME_MIN_LENGTH;
 }

--- a/tests/libslac_unit_test.cpp
+++ b/tests/libslac_unit_test.cpp
@@ -3,6 +3,11 @@
 
 #include <gtest/gtest.h>
 #include <slac/slac.hpp>
+#include <slac/channel.hpp>
+#include <slac/transport.hpp>
+#include <vector>
+#include <algorithm>
+#include <cstring>
 
 namespace libslac {
 class LibSLACUnitTest : public ::testing::Test {
@@ -12,6 +17,28 @@ protected:
 
     void TearDown() override {
     }
+};
+
+class FakeLink : public slac::transport::Link {
+public:
+    std::vector<uint8_t> data;
+
+    bool open() override { return true; }
+    bool write(const uint8_t*, size_t, uint32_t) override { return true; }
+    bool read(uint8_t* buf, size_t len, size_t* out_len, uint32_t) override {
+        size_t n = std::min(len, data.size());
+        if (n == 0) {
+            *out_len = 0;
+            return false;
+        }
+        memcpy(buf, data.data(), n);
+        *out_len = n;
+        return true;
+    }
+    const uint8_t* mac() const override { return mac_addr; }
+
+private:
+    uint8_t mac_addr[ETH_ALEN]{0};
 };
 
 TEST_F(LibSLACUnitTest, test_invalid_datetime) {
@@ -25,6 +52,30 @@ TEST_F(LibSLACUnitTest, test_generate_nid_from_nmk_check_security_bits) {
 
     slac::utils::generate_nid_from_nmk(nid, sample_nmk);
     ASSERT_TRUE((nid[6] >> 4) == 0x00);
+}
+
+TEST_F(LibSLACUnitTest, test_channel_read_sets_length) {
+    FakeLink link;
+    link.data.resize(80, 0xaa);
+
+    slac::Channel channel(&link);
+    ASSERT_TRUE(channel.open());
+
+    slac::messages::HomeplugMessage msg;
+    ASSERT_TRUE(channel.read(msg, 0));
+    ASSERT_EQ(msg.get_raw_msg_len(), static_cast<int>(link.data.size()));
+}
+
+TEST_F(LibSLACUnitTest, test_channel_poll_sets_length) {
+    FakeLink link;
+    link.data.resize(64, 0xbb);
+
+    slac::Channel channel(&link);
+    ASSERT_TRUE(channel.open());
+
+    slac::messages::HomeplugMessage msg;
+    ASSERT_TRUE(channel.poll(msg));
+    ASSERT_EQ(msg.get_raw_msg_len(), static_cast<int>(link.data.size()));
 }
 
 } // namespace libslac


### PR DESCRIPTION
## Summary
- allow `HomeplugMessage` to store the length of the last raw message read
- keep the length from `Link::read` calls in `Channel::read` and `Channel::poll`
- add unit tests verifying length handling

## Testing
- `cmake --build build`
- `ctest --test-dir build`

------
https://chatgpt.com/codex/tasks/task_e_688138d644bc832491e409d3a758924b