### PR TITLE
Clarify assumptions in header comments

### DIFF
--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -16,11 +16,9 @@
 
 namespace slac {
 
-// TODO (aw):
-//  - do we need to handle VLAN tags?
-//  - probably we need to handle different sessions ...
-//  - channel could own the interface handle and pass it to the packet
-//    socket
+// Note: VLAN tags are currently not supported.  All traffic is assumed to be
+// untagged.  Only a single session is handled at a time and the interface
+// handle is managed outside the Channel class.
 
 class Channel {
 public:

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -24,9 +24,9 @@
 
 namespace slac {
 
-// TODO (aw):
-//  - is run_id 8 or 16 bytes?
-//  - is nid 7 or 8 bytes?
+// Current implementation assumes that a run_id consists of 8 bytes.  The NID
+// value is assumed to use only 7 bytes with the most significant bits of the
+// eighth byte reserved.
 
 namespace defs {
 


### PR DESCRIPTION
## Summary
- clarify that VLAN tags are not handled in `Channel`
- document assumption about run id and nid sizes in `slac.hpp`

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68813efef5448324818d7fef043ffabf