### PR TITLE
Add platform wrappers and refine MCU build sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,24 @@ target_include_directories(slac PUBLIC
     $<INSTALL_INTERFACE:include>
 )
 
-target_sources(slac
-    PRIVATE
-        src/channel.cpp
-        src/slac.cpp
-        $<IF:$<BOOL:${ESP_PLATFORM}>,port/esp32s3/qca7000_link.cpp,src/packet_socket.cpp>
-        $<$<NOT:$<BOOL:${ESP_PLATFORM}>>:src/packet_socket_link.cpp>
-        $<$<BOOL:${ESP_PLATFORM}>:port/esp32s3/qca7000.cpp>
-        $<TARGET_OBJECTS:HashLibrary>
+set(SLAC_SOURCES
+    src/channel.cpp
+    src/slac.cpp
 )
+
+if(ESP_PLATFORM)
+    list(APPEND SLAC_SOURCES
+        port/esp32s3/qca7000_link.cpp
+        port/esp32s3/qca7000.cpp
+    )
+else()
+    list(APPEND SLAC_SOURCES
+        src/packet_socket.cpp
+        src/packet_socket_link.cpp
+    )
+endif()
+
+target_sources(slac PRIVATE ${SLAC_SOURCES} $<TARGET_OBJECTS:HashLibrary>)
 
 if(ESP_PLATFORM)
     target_include_directories(slac PRIVATE port/esp32s3)

--- a/include/slac/packet_socket.hpp
+++ b/include/slac/packet_socket.hpp
@@ -7,7 +7,7 @@
 #include <string>
 
 #ifndef ESP_PLATFORM
-#include <linux/if_ether.h>
+#include <slac/platform/if_ether.hpp>
 #endif
 
 namespace utils {

--- a/include/slac/platform/if_ether.hpp
+++ b/include/slac/platform/if_ether.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifndef ESP_PLATFORM
+#include <linux/if_ether.h>
+#else
+#include "port/esp32s3/ethernet_defs.hpp"
+#endif

--- a/include/slac/platform/if_packet.hpp
+++ b/include/slac/platform/if_packet.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#ifndef ESP_PLATFORM
+#include <linux/if_packet.h>
+#else
+struct sockaddr_ll {
+    unsigned short sll_family;
+    unsigned short sll_protocol;
+    int sll_ifindex;
+    unsigned short sll_hatype;
+    unsigned char sll_pkttype;
+    unsigned char sll_halen;
+    unsigned char sll_addr[8];
+};
+
+#ifndef AF_PACKET
+#define AF_PACKET 17
+#endif
+#endif

--- a/include/slac/platform/ifaddrs.hpp
+++ b/include/slac/platform/ifaddrs.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifndef ESP_PLATFORM
+#include <ifaddrs.h>
+#else
+struct ifaddrs;
+static inline int getifaddrs(struct ifaddrs**) { return -1; }
+static inline void freeifaddrs(struct ifaddrs*) {}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -5,7 +5,7 @@ src_dir = .
 platform = native
 build_flags = -Iinclude -I3rd_party
 lib_ldf_mode = off
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<src/packet_socket.cpp> +<src/packet_socket_link.cpp> +<3rd_party/hash_library/sha256.cpp> -<port/esp32s3/qca7000_link.cpp>
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<src/packet_socket.cpp> +<src/packet_socket_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp> -<port/esp32s3/qca7000_link.cpp>
 
 [env:esp32s3]
 platform = espressif32@6.5.0
@@ -14,4 +14,4 @@ framework = arduino
 build_unflags = -std=gnu++11
 build_flags = -std=gnu++17 -Iinclude -I3rd_party -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp>
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>

--- a/src/packet_socket.cpp
+++ b/src/packet_socket.cpp
@@ -6,9 +6,9 @@
 
 #ifndef ESP_PLATFORM
 #include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <linux/if_packet.h>
 #include <poll.h>
+#include <slac/platform/if_packet.hpp>
+#include <slac/platform/ifaddrs.hpp>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/src/packet_socket_link.cpp
+++ b/src/packet_socket_link.cpp
@@ -1,15 +1,16 @@
 #include <slac/packet_socket_link.hpp>
 
 #ifndef ESP_PLATFORM
-#include <linux/if_ether.h>
+#include <slac/platform/if_ether.hpp>
 #endif
-#include <memory>
 #include <cstring>
+#include <memory>
 #include <slac/slac.hpp>
 
 namespace slac {
 
-PacketSocketLink::PacketSocketLink(const std::string& if_name) : interface_name(if_name) {}
+PacketSocketLink::PacketSocketLink(const std::string& if_name) : interface_name(if_name) {
+}
 
 bool PacketSocketLink::open() {
     ::utils::InterfaceInfo if_info(interface_name);

--- a/tools/bridge.cpp
+++ b/tools/bridge.cpp
@@ -3,12 +3,12 @@
 #include <string>
 
 #include <arpa/inet.h>
-#include <ifaddrs.h>
-#include <linux/if_ether.h>
-#include <linux/if_packet.h>
-#include <poll.h>
-#include <cstring>
 #include <cerrno>
+#include <cstring>
+#include <poll.h>
+#include <slac/platform/if_ether.hpp>
+#include <slac/platform/if_packet.hpp>
+#include <slac/platform/ifaddrs.hpp>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -129,8 +129,7 @@ void handle_set_key_req(PLCDeviceInformation& node, const slac::messages::homepl
     set_key_cnf.cco_capability = slac::defs::CM_SET_KEY_REQ_CCO_CAP_NONE;
 
     response.setup_payload(&set_key_cnf, sizeof(set_key_cnf),
-                           slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF,
-                           slac::defs::MMV::AV_1_0);
+                           slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF, slac::defs::MMV::AV_1_0);
     response.setup_ethernet_header(request.ethernet_header.ether_shost, node.plc_mac);
 }
 
@@ -146,8 +145,7 @@ void handle_mnbc_sound_ind(PLCDeviceInformation& forward_node, const slac::messa
     }
 
     response.setup_payload(&atten_profile, sizeof(atten_profile),
-                           slac::defs::MMTYPE_CM_ATTEN_PROFILE | slac::defs::MMTYPE_MODE_IND,
-                           slac::defs::MMV::AV_1_0);
+                           slac::defs::MMTYPE_CM_ATTEN_PROFILE | slac::defs::MMTYPE_MODE_IND, slac::defs::MMV::AV_1_0);
     response.setup_ethernet_header(slac::defs::BROADCAST_MAC_ADDRESS, forward_node.plc_mac);
 }
 


### PR DESCRIPTION
## Summary
- add `slac/platform` headers to stub out Linux-only headers on microcontrollers
- switch code to include wrapper headers
- refine source selection logic in `CMakeLists.txt`
- include example main file in PlatformIO builds

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release`
- `cmake --build .`
- `pio run -e esp32s3`
- `pio run -e host`


------
https://chatgpt.com/codex/tasks/task_e_688140831f148324b8d9c5b95614c6e5