### PR TITLE
Refactor iso15118 constants

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ Library Concepts
     Representation of a HomePlug AV frame used to carry SLAC payloads.
 
 The header ``slac/slac.hpp`` also defines all SLAC message structures and constants.
+Timing constants used during ISO15118-3 matching are provided in ``slac/iso15118_consts.hpp``.
 
 Using the Library
 -----------------

--- a/include/slac/iso15118_consts.hpp
+++ b/include/slac/iso15118_consts.hpp
@@ -1,0 +1,23 @@
+#ifndef SLAC_ISO15118_CONSTS_HPP
+#define SLAC_ISO15118_CONSTS_HPP
+
+namespace slac {
+namespace defs {
+
+const int C_EV_START_ATTEN_CHAR_INDS = 3;
+const int C_EV_MATCH_RETRY = 2;
+const int C_EV_MATCH_MNBC = 10;
+const int TP_EV_BATCH_MSG_INTERVAL_MS = 40; // 20ms - 50ms, interval between start_atten_char and mnbc_sound msgs
+const int TT_EV_ATTEN_RESULTS_MS = 1200;    // max. 1200ms
+const int TT_EVSE_MATCH_MNBC_MS = 600;
+const int TT_MATCH_SEQUENCE_MS = 400;
+const int TT_MATCH_RESPONSE_MS = 200;
+const int TT_EVSE_MATCH_SESSION_MS = 10000;
+const int TT_EVSE_SLAC_INIT_MS = 40000; // (20s - 50s)
+const int TT_MATCH_JOIN_MS = 12000;     // max. 12s
+const int T_STEP_EF_MS = 4000;          // min. 4s
+
+} // namespace defs
+} // namespace slac
+
+#endif // SLAC_ISO15118_CONSTS_HPP

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -13,11 +13,11 @@
 #if defined(ESP_PLATFORM)
 #include "port/esp32s3/ethernet_defs.hpp"
 #elif defined(__has_include)
-#  if __has_include(<net/ethernet.h>)
-#    include <net/ethernet.h>
-#  else
-#    include "port/esp32s3/ethernet_defs.hpp"
-#  endif
+#if __has_include(<net/ethernet.h>)
+#include <net/ethernet.h>
+#else
+#include "port/esp32s3/ethernet_defs.hpp"
+#endif
 #else
 #include <net/ethernet.h>
 #endif
@@ -53,20 +53,6 @@ const int NMK_LEN = 16;
 
 const int AAG_LIST_LEN = 58;
 const int RUN_ID_LEN = 8;
-
-// FIXME (aw): where to put these iso15118/3 consts?
-const int C_EV_START_ATTEN_CHAR_INDS = 3;
-const int C_EV_MATCH_RETRY = 2;
-const int C_EV_MATCH_MNBC = 10;
-const int TP_EV_BATCH_MSG_INTERVAL_MS = 40; // 20ms - 50ms, interval between start_atten_char and mnbc_sound msgs
-const int TT_EV_ATTEN_RESULTS_MS = 1200;    // max. 1200ms
-const int TT_EVSE_MATCH_MNBC_MS = 600;
-const int TT_MATCH_SEQUENCE_MS = 400;
-const int TT_MATCH_RESPONSE_MS = 200;
-const int TT_EVSE_MATCH_SESSION_MS = 10000;
-const int TT_EVSE_SLAC_INIT_MS = 40000; // (20s - 50s)
-const int TT_MATCH_JOIN_MS = 12000;     // max. 12s
-const int T_STEP_EF_MS = 4000;          // min. 4s
 
 const uint16_t MMTYPE_CM_SET_KEY = 0x6008;
 const uint16_t MMTYPE_CM_SLAC_PARAM = 0x6064;

--- a/tools/evse/evse_fsm.cpp
+++ b/tools/evse/evse_fsm.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 
 #include "../logging.hpp"
+#include <slac/iso15118_consts.hpp>
 
 // FIXME (aw):
 //  - handle evse, ev, sender and source id, probably also the mac
@@ -14,8 +15,7 @@ void setup_atten_char_ind_message(slac::messages::HomeplugMessage& msg, const Ma
     auto atten_char_ind = matching_ctx.calculate_avg();
 
     msg.setup_payload(&atten_char_ind, sizeof(atten_char_ind),
-                      slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND,
-                      slac::defs::MMV::AV_1_0);
+                      slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND, slac::defs::MMV::AV_1_0);
     msg.setup_ethernet_header(matching_ctx.ev_mac);
 }
 
@@ -56,8 +56,7 @@ EvseFSM::EvseFSM(SlacIO& slac_io) : slac_io(slac_io) {
         memcpy(set_key_req.new_key, session_nmk, sizeof(set_key_req.new_key));
 
         msg_out.setup_payload(&set_key_req, sizeof(set_key_req),
-                               slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ,
-                               slac::defs::MMV::AV_1_0);
+                              slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ, slac::defs::MMV::AV_1_0);
 
         msg_out.setup_ethernet_header(plc_peer_mac);
 
@@ -280,8 +279,7 @@ void EvseFSM::sd_wait_for_matching_hsm(FSMContextType& ctx, const EventSlacMessa
 
     msg_out.setup_ethernet_header(param_confirm.forwarding_sta);
     msg_out.setup_payload(&param_confirm, sizeof(param_confirm),
-                          slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF,
-                          slac::defs::MMV::AV_1_0);
+                          slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, slac::defs::MMV::AV_1_0);
 
     slac_io.send(msg_out);
 
@@ -406,8 +404,7 @@ void EvseFSM::sd_wait_for_slac_match_hsm(FSMContextType& ctx, const EventSlacMes
     memcpy(match_cnf.nmk, session_nmk, sizeof(match_cnf.nmk));
 
     msg_out.setup_ethernet_header(matching_ctx.ev_mac);
-    msg_out.setup_payload(&match_cnf, sizeof(match_cnf),
-                          slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF,
+    msg_out.setup_payload(&match_cnf, sizeof(match_cnf), slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF,
                           slac::defs::MMV::AV_1_0);
 
     slac_io.send(msg_out);


### PR DESCRIPTION
## Summary
- move ISO15118 timing constants from `slac.hpp` to new `iso15118_consts.hpp`
- include the new header in EVSE FSM
- document the new header in README

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug`
- `ninja`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688142e014d883248b400967128f9c0e