### PR TITLE
Clarify non-blocking socket usage

### DIFF
--- a/src/packet_socket.cpp
+++ b/src/packet_socket.cpp
@@ -49,7 +49,9 @@ InterfaceInfo::InterfaceInfo(const std::string& interface_name) {
 }
 
 PacketSocket::PacketSocket(const InterfaceInfo& if_info, int protocol) {
-    // FIXME (aw): do we need to use O_NONBLOCKING?
+    // Open the socket in non blocking mode. We rely on poll() for the
+    // blocking behaviour and non-blocking sockets guard against potential
+    // race conditions between poll() and read()/write().
     socket_fd = socket(AF_PACKET, SOCK_RAW | SOCK_NONBLOCK, htons(protocol));
 
     if (socket_fd == -1) {


### PR DESCRIPTION
## Summary
- retain non-blocking behaviour for PacketSocket
- document why the raw packet socket uses `SOCK_NONBLOCK`

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_688142d56cf08324b175410996b80b53