### PR TITLE
Limit build to microcontroller sources

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,26 +50,14 @@ target_include_directories(slac PUBLIC
 set(SLAC_SOURCES
     src/channel.cpp
     src/slac.cpp
+    port/esp32s3/qca7000_link.cpp
+    port/esp32s3/qca7000.cpp
 )
-
-if(ESP_PLATFORM)
-    list(APPEND SLAC_SOURCES
-        port/esp32s3/qca7000_link.cpp
-        port/esp32s3/qca7000.cpp
-    )
-else()
-    list(APPEND SLAC_SOURCES
-        src/packet_socket.cpp
-        src/packet_socket_link.cpp
-    )
-endif()
 
 target_sources(slac PRIVATE ${SLAC_SOURCES} $<TARGET_OBJECTS:HashLibrary>)
 
-if(ESP_PLATFORM)
-    target_include_directories(slac PRIVATE port/esp32s3)
-    target_compile_options(slac PRIVATE -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti)
-endif()
+target_include_directories(slac PRIVATE port/esp32s3)
+target_compile_options(slac PRIVATE -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti)
 
 if (BUILD_SLAC_TOOLS)
     add_subdirectory(tools)

--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ creating :class:`slac::port::Qca7000Link`:
 Tools and Examples
 ------------------
 
-The ``tools`` directory contains small utilities demonstrating how to use ``libslac``. ``tools/bridge.cpp`` shows how to forward packets between two virtual interfaces. The ``tools/evse`` directory contains a simple state machine for the EVSE side of the SLAC handshake.
+The ``tools`` directory contains small utilities demonstrating how to use ``libslac``. ``tools/evse`` contains a simple state machine for the EVSE side of the SLAC handshake. ``tools/bridge.cpp`` can forward packets between two virtual interfaces on Linux and is disabled on microcontroller builds.
 
 Running the Tests
 -----------------

--- a/include/slac/platform/if_ether.hpp
+++ b/include/slac/platform/if_ether.hpp
@@ -1,7 +1,3 @@
 #pragma once
 
-#ifndef ESP_PLATFORM
-#include <linux/if_ether.h>
-#else
-#include "port/esp32s3/ethernet_defs.hpp"
-#endif
+#include "ethernet_defs.hpp"

--- a/include/slac/platform/if_packet.hpp
+++ b/include/slac/platform/if_packet.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#ifndef ESP_PLATFORM
-#include <linux/if_packet.h>
-#else
+#include "ethernet_defs.hpp"
+
 struct sockaddr_ll {
     unsigned short sll_family;
     unsigned short sll_protocol;
@@ -15,5 +14,4 @@ struct sockaddr_ll {
 
 #ifndef AF_PACKET
 #define AF_PACKET 17
-#endif
 #endif

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -10,17 +10,7 @@
 #include <cstdint>
 #include <utility>
 
-#if defined(ESP_PLATFORM)
-#include "port/esp32s3/ethernet_defs.hpp"
-#elif defined(__has_include)
-#if __has_include(<net/ethernet.h>)
-#include <net/ethernet.h>
-#else
-#include "port/esp32s3/ethernet_defs.hpp"
-#endif
-#else
-#include <net/ethernet.h>
-#endif
+#include "ethernet_defs.hpp"
 
 namespace slac {
 

--- a/pio_src/main.cpp
+++ b/pio_src/main.cpp
@@ -2,25 +2,21 @@
 #include <Arduino.h>
 #endif
 #include <slac/channel.hpp>
-#include <slac/transport.hpp>
+#include <port/esp32s3/qca7000_link.hpp>
 
 #ifdef ARDUINO
-static slac::transport::Link* g_link = nullptr; // placeholder
+static slac::port::Qca7000Link* g_link = nullptr;
 static slac::Channel* channel = nullptr;
 
 void setup() {
+    static const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+    g_link = new slac::port::Qca7000Link(cfg);
     channel = new slac::Channel(g_link);
     channel->open();
 }
 
 void loop() {
     // placeholder main loop
-}
-#else
-int main() {
-    slac::transport::Link* link = nullptr; // placeholder
-    slac::Channel ch(link);
-    ch.open();
-    return 0;
 }
 #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,17 +1,11 @@
 [platformio]
 src_dir = .
 
-[env:host]
-platform = native
-build_flags = -Iinclude -I3rd_party
-lib_ldf_mode = off
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<src/packet_socket.cpp> +<src/packet_socket_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp> -<port/esp32s3/qca7000_link.cpp>
-
 [env:esp32s3]
 platform = espressif32@6.5.0
 board = esp32-s3-devkitc-1
 framework = arduino
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -Iinclude -I3rd_party -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
 src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>

--- a/src/packet_socket.cpp
+++ b/src/packet_socket.cpp
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
+#ifndef ESP_PLATFORM
 #include <slac/packet_socket.hpp>
 
 #include <cstring>
 
-#ifndef ESP_PLATFORM
 #include <arpa/inet.h>
 #include <poll.h>
 #include <slac/platform/if_packet.hpp>
@@ -12,7 +12,6 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#endif
 
 namespace utils {
 InterfaceInfo::InterfaceInfo(const std::string& interface_name) {
@@ -150,3 +149,4 @@ PacketSocket::IOResult PacketSocket::write(const void* buf, size_t size, int tim
 }
 
 } // namespace utils
+#endif // !ESP_PLATFORM

--- a/src/packet_socket_link.cpp
+++ b/src/packet_socket_link.cpp
@@ -1,8 +1,7 @@
+#ifndef ESP_PLATFORM
 #include <slac/packet_socket_link.hpp>
 
-#ifndef ESP_PLATFORM
 #include <slac/platform/if_ether.hpp>
-#endif
 #include <cstring>
 #include <memory>
 #include <slac/slac.hpp>
@@ -50,3 +49,4 @@ const uint8_t* PacketSocketLink::mac() const {
 }
 
 } // namespace slac
+#endif // !ESP_PLATFORM

--- a/tools/bridge.cpp
+++ b/tools/bridge.cpp
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
+
+#ifndef ESP_PLATFORM
 #include <string>
 
 #include <arpa/inet.h>
@@ -239,3 +241,5 @@ int main(int argc, char* argv[]) {
 
     return 0;
 }
+
+#endif // !ESP_PLATFORM


### PR DESCRIPTION
## Summary
- default to the ESP32-S3 port
- guard Linux-only sources
- drop direct <linux/...> and <net/...> includes
- provide a basic Qca7000Link example

## Testing
- `pio run -e esp32s3`
- `cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build` *(fails: esp_log.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881450660d8832499080b0b5c0921b0