### PR TITLE
Fix host build by restoring platform conditions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,25 @@ target_include_directories(slac PUBLIC
 set(SLAC_SOURCES
     src/channel.cpp
     src/slac.cpp
-    port/esp32s3/qca7000_link.cpp
-    port/esp32s3/qca7000.cpp
 )
+
+if (ESP_PLATFORM)
+    list(APPEND SLAC_SOURCES
+        port/esp32s3/qca7000_link.cpp
+        port/esp32s3/qca7000.cpp
+    )
+else()
+    list(APPEND SLAC_SOURCES
+        src/packet_socket.cpp
+        src/packet_socket_link.cpp
+    )
+endif()
 
 target_sources(slac PRIVATE ${SLAC_SOURCES} $<TARGET_OBJECTS:HashLibrary>)
 
-target_include_directories(slac PRIVATE port/esp32s3)
+if (ESP_PLATFORM)
+    target_include_directories(slac PRIVATE port/esp32s3)
+endif()
 target_compile_options(slac PRIVATE -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti)
 
 if (BUILD_SLAC_TOOLS)

--- a/include/slac/platform/if_ether.hpp
+++ b/include/slac/platform/if_ether.hpp
@@ -1,3 +1,7 @@
 #pragma once
 
-#include "ethernet_defs.hpp"
+#ifndef ESP_PLATFORM
+#include <linux/if_ether.h>
+#else
+#include "port/esp32s3/ethernet_defs.hpp"
+#endif

--- a/include/slac/platform/if_packet.hpp
+++ b/include/slac/platform/if_packet.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "ethernet_defs.hpp"
-
+#ifndef ESP_PLATFORM
+#include <linux/if_packet.h>
+#else
 struct sockaddr_ll {
     unsigned short sll_family;
     unsigned short sll_protocol;
@@ -14,4 +15,5 @@ struct sockaddr_ll {
 
 #ifndef AF_PACKET
 #define AF_PACKET 17
+#endif
 #endif

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -10,7 +10,17 @@
 #include <cstdint>
 #include <utility>
 
-#include "ethernet_defs.hpp"
+#if defined(ESP_PLATFORM)
+#include "port/esp32s3/ethernet_defs.hpp"
+#elif defined(__has_include)
+#if __has_include(<net/ethernet.h>)
+#include <net/ethernet.h>
+#else
+#include "port/esp32s3/ethernet_defs.hpp"
+#endif
+#else
+#include <net/ethernet.h>
+#endif
 
 namespace slac {
 


### PR DESCRIPTION
## Summary
- make library sources depend on `ESP_PLATFORM`
- only add `port/esp32s3` include path when building for ESP32
- restore platform dependent headers so host build uses system headers

## Testing
- `cmake -S . -B build-host -G Ninja`
- `cmake --build build-host`
- `pio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_68814c0d4ca08324abe463c65c21d489