### PR TITLE
Fix EVSE link selection

### DIFF
--- a/tools/evse/evse_fsm.cpp
+++ b/tools/evse/evse_fsm.cpp
@@ -6,6 +6,7 @@
 
 #include "../logging.hpp"
 #include <slac/iso15118_consts.hpp>
+#include <cstring>
 
 // FIXME (aw):
 //  - handle evse, ev, sender and source id, probably also the mac

--- a/tools/evse/packet_socket_link.cpp
+++ b/tools/evse/packet_socket_link.cpp
@@ -1,4 +1,5 @@
 #include "packet_socket_link.hpp"
+#include <slac/slac.hpp>
 
 PacketSocketLink::PacketSocketLink(const std::string& if_name) : if_name(if_name) {
 }

--- a/tools/evse/packet_socket_link.hpp
+++ b/tools/evse/packet_socket_link.hpp
@@ -3,7 +3,7 @@
 
 #include <memory>
 #include <slac/transport.hpp>
-#include "../../src/packet_socket.hpp"
+#include <slac/packet_socket.hpp>
 
 class PacketSocketLink : public slac::transport::Link {
 public:

--- a/tools/evse/slac_io.cpp
+++ b/tools/evse/slac_io.cpp
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include "slac_io.hpp"
-#include "packet_socket_link.hpp"
+#ifdef ESP_PLATFORM
+#include <port/esp32s3/qca7000_link.hpp>
+#else
+#include <slac/packet_socket_link.hpp>
+#endif
 
 #include <stdexcept>
 #ifdef ESP_PLATFORM
@@ -10,7 +14,11 @@
 #include <thread>
 #endif
 
+#ifdef ESP_PLATFORM
+SlacIO::SlacIO(const slac::port::qca7000_config& cfg) : link(cfg), slac_channel(&link) {
+#else
 SlacIO::SlacIO(const std::string& if_name) : link(if_name), slac_channel(&link) {
+#endif
     if (!slac_channel.open()) {
         throw std::runtime_error("Failed to open channel");
     }

--- a/tools/evse/slac_io.hpp
+++ b/tools/evse/slac_io.hpp
@@ -14,12 +14,20 @@
 #endif
 
 #include <slac/channel.hpp>
+#ifdef ESP_PLATFORM
+#include <port/esp32s3/qca7000_link.hpp>
+#else
 #include <slac/packet_socket_link.hpp>
+#endif
 
 class SlacIO {
 public:
     using InputHandlerFnType = void(slac::messages::HomeplugMessage&);
+#ifdef ESP_PLATFORM
+    explicit SlacIO(const slac::port::qca7000_config& cfg);
+#else
     explicit SlacIO(const std::string& if_name);
+#endif
 
     void release_input();
     /**
@@ -41,7 +49,11 @@ public:
 
 private:
     void loop();
+#ifdef ESP_PLATFORM
+    slac::port::Qca7000Link link;
+#else
     slac::PacketSocketLink link;
+#endif
 
     slac::Channel slac_channel;
     slac::messages::HomeplugMessage incoming_msg;


### PR DESCRIPTION
## Summary
- let SlacIO pick PacketSocketLink or Qca7000Link depending on ESP_PLATFORM
- include `<cstring>` for EVSE FSM
- clean up PacketSocketLink includes for tools build

## Testing
- `cmake --build build --target evse`
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_68814e20c56c8324bed37515fb00c13e