### PR TITLE
Add timing helpers for ESP32 port

### DIFF
--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -4,10 +4,43 @@
 #include <stdint.h>
 
 #ifdef ESP_PLATFORM
-static inline uint16_t le16toh(uint16_t v) { return v; }
-static inline uint16_t htole16(uint16_t v) { return v; }
-static inline uint32_t le32toh(uint32_t v) { return v; }
-static inline uint32_t htole32(uint32_t v) { return v; }
+static inline uint16_t le16toh(uint16_t v) {
+    return v;
+}
+static inline uint16_t htole16(uint16_t v) {
+    return v;
+}
+static inline uint32_t le32toh(uint32_t v) {
+    return v;
+}
+static inline uint32_t htole32(uint32_t v) {
+    return v;
+}
+
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
+#include <freertos/task.h>
+static inline uint32_t slac_millis() {
+    return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+static inline void slac_delay(uint32_t ms) {
+    vTaskDelay(pdMS_TO_TICKS(ms));
+}
+static inline void slac_noInterrupts() {
+    portDISABLE_INTERRUPTS();
+}
+static inline void slac_interrupts() {
+    portENABLE_INTERRUPTS();
+}
+#else
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+#define slac_millis       millis
+#define slac_delay(ms)    delay(ms)
+#define slac_noInterrupts noInterrupts
+#define slac_interrupts   interrupts
 #endif
 
 #endif // SLAC_PORT_CONFIG_HPP

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -1,7 +1,5 @@
-#ifdef ESP_PLATFORM
-#include "port_config.hpp"
-#endif
 #include "qca7000_link.hpp"
+#include "port_config.hpp"
 #include "qca7000.hpp"
 
 namespace slac {
@@ -42,7 +40,7 @@ bool Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
         *out = 0;
         return false;
     }
-    uint32_t start = millis();
+    uint32_t start = slac_millis();
     do {
         size_t got = spiQCA7000checkForReceivedData(b, l);
         if (got) {
@@ -51,8 +49,8 @@ bool Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
         }
         if (timeout_ms == 0)
             break;
-        delay(1);
-    } while (millis() - start < timeout_ms);
+        slac_delay(1);
+    } while (slac_millis() - start < timeout_ms);
     *out = 0;
     return false;
 }


### PR DESCRIPTION
## Summary
- add wrappers for millis/delay/interrupt helpers
- update QCA7000 drivers to use the wrappers

## Testing
- `pio run -e esp32s3`
- `cmake .. -G Ninja && ninja`
- `cmake .. -G Ninja -DESP_PLATFORM=ON` *(fails: esp_log.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68815045d8d88324bff09331db912b49