### PR TITLE
Add simple SLAC handshake helpers

### DIFF
--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -68,6 +68,8 @@ uint16_t qca7000ReadInternalReg(uint8_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
+bool qca7000startSlac();
+uint8_t qca7000getSlacResult();
 void qca7000Process();
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>


### PR DESCRIPTION
## Summary
- implement CM_SLAC_PARAM.REQ transmit and parsing of replies on ESP32
- expose qca7000startSlac() and qca7000getSlacResult() in the header

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6881fc6405fc83249352ed7e607a68e8