### PR TITLE
Handle Qca7000 initialization errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,14 @@ An example for the ESP32-S3 port:
    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
    slac::port::Qca7000Link link(cfg);
    slac::Channel channel(&link);
-   channel.open();
+   if (!channel.open()) {
+       // initialization failed, query link.init_failed() for details
+       return;
+   }
+
+When :func:`channel.open()` fails, the link enters an error state and further
+calls will not attempt to reinitialise the modem.  Call
+``link.init_failed()`` to query this condition and react accordingly.
 
 QCA7000 Configuration
 ---------------------

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -12,12 +12,16 @@ Qca7000Link::Qca7000Link(const qca7000_config& c) : cfg(c) {
 bool Qca7000Link::open() {
     if (initialized)
         return true;
+    if (initialization_error)
+        return false;
 
     SPIClass* bus = cfg.spi ? cfg.spi : &SPI;
     int cs = cfg.cs_pin ? cfg.cs_pin : PLC_SPI_CS_PIN;
 
-    if (!qca7000setup(bus, cs))
+    if (!qca7000setup(bus, cs)) {
+        initialization_error = true;
         return false;
+    }
 
     if (cfg.mac_addr)
         memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);
@@ -30,13 +34,13 @@ bool Qca7000Link::open() {
 }
 
 bool Qca7000Link::write(const uint8_t* b, size_t l, uint32_t) {
-    if (!initialized)
+    if (!initialized || initialization_error)
         return false;
     return spiQCA7000SendEthFrame(b, l);
 }
 
 bool Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
-    if (!initialized) {
+    if (!initialized || initialization_error) {
         *out = 0;
         return false;
     }

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -5,9 +5,9 @@
 #include "port_config.hpp"
 #endif
 
-#include <slac/transport.hpp>
 #include "ethernet_defs.hpp"
 #include "qca7000.hpp"
+#include <slac/transport.hpp>
 
 namespace slac {
 namespace port {
@@ -21,8 +21,23 @@ public:
     bool read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 
+    /**
+     * @brief Returns true if an initialization error has occurred.
+     */
+    bool init_failed() const {
+        return initialization_error;
+    }
+
+    /**
+     * @brief Returns true if the link was successfully opened.
+     */
+    bool is_initialized() const {
+        return initialized;
+    }
+
 private:
     bool initialized{false};
+    bool initialization_error{false};
     qca7000_config cfg;
     uint8_t mac_addr[ETH_ALEN]{};
 };


### PR DESCRIPTION
## Summary
- track initialization failures in `Qca7000Link`
- expose `init_failed()` and `is_initialized()` accessors
- document error checking in README

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_688207467b1883248f08822d2bf6e66c