### PR TITLE
Fix ring buffer overflow handling in ESP32S3 driver

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -42,11 +42,15 @@ inline void ringPush(const uint8_t* d, size_t l) {
     slac_noInterrupts();
     if (l > V2GTP_BUFFER_SIZE)
         l = V2GTP_BUFFER_SIZE;
+    uint8_t next = (head + 1) & 3;
+    if (next == tail) {
+        slac_interrupts();
+        ESP_LOGW(PLC_TAG, "RX ring full - dropping frame");
+        return;
+    }
     memcpy(ring[head].data, d, l);
     ring[head].len = l;
-    head = (head + 1) & 3;
-    if (head == tail)
-        tail = (tail + 1) & 3;
+    head = next;
     slac_interrupts();
 }
 inline bool ringPop(const uint8_t** d, size_t* l) {


### PR DESCRIPTION
## Summary
- avoid overwriting unread frames in `ringPush`
- log a warning when RX buffer is full

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_6882073fd5548324a73cf10227ac64d9