### PR TITLE
Add QCA7000 SPI unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,9 +1,11 @@
 add_executable(slac_unit_test
     libslac_unit_test.cpp
     evse_fsm_test.cpp
+    qca7000_test.cpp
     ../tools/evse/evse_fsm.cpp
     ../tools/evse/slac_io.cpp
     ../tools/evse/packet_socket_link.cpp
+    stubs/SPI.cpp
 )
 
 find_package(GTest REQUIRED)
@@ -17,6 +19,8 @@ target_include_directories(slac_unit_test PUBLIC
     ${GTEST_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../3rd_party/libfsm
     ${CMAKE_CURRENT_SOURCE_DIR}/../tools/evse
+    ${CMAKE_CURRENT_SOURCE_DIR}/stubs
+    ${CMAKE_CURRENT_SOURCE_DIR}/../port/esp32s3
 )
 
 target_link_libraries(slac_unit_test PRIVATE

--- a/tests/qca7000_test.cpp
+++ b/tests/qca7000_test.cpp
@@ -1,0 +1,73 @@
+#include <gtest/gtest.h>
+
+#define LIBSLAC_TESTING
+#define ARDUINO
+#define SLAC_ETHERNET_DEFS_HPP
+#include "../port/esp32s3/qca7000.cpp"
+#include "stubs/SPI.h"
+#include <endian.h>
+#include <net/ethernet.h>
+
+class QCA7000Test : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_spi = &SPI;
+        g_cs = 5;
+        SPI.read_queue.clear();
+        SPI.read16_queue.clear();
+        SPI.written.clear();
+        SPI.transferred.clear();
+        SPI.transferred16.clear();
+    }
+};
+
+TEST_F(QCA7000Test, txFramePaddingAndMarkers) {
+    uint8_t frame[4] = {1, 2, 3, 4};
+    SPI.read16_queue.push_back(0);    // dummy for first transfer16
+    SPI.read16_queue.push_back(1000); // space available for second transfer16
+    bool ok = txFrame(frame, sizeof(frame));
+    ASSERT_TRUE(ok);
+    ASSERT_GE(SPI.transferred16.size(), 6u);
+    size_t off = SPI.transferred16.size() - 6;
+    EXPECT_EQ(SPI.transferred16[off + 1], 0xAAAA);      // SOF
+    EXPECT_EQ(SPI.transferred16[off + 2], 0xAAAA);      // SOF
+    EXPECT_EQ(SPI.transferred16[off + 3], htole16(60)); // length
+    EXPECT_EQ(SPI.transferred16[off + 5], 0x5555);      // EOF
+    ASSERT_EQ(SPI.written.size(), 60u);
+    EXPECT_TRUE(std::equal(frame, frame + sizeof(frame), SPI.written.begin()));
+}
+
+TEST_F(QCA7000Test, fetchRxExtractsFrame) {
+    const uint16_t frame_len = 14;
+    const uint16_t avail = RX_HDR + frame_len + FTR_LEN;
+    SPI.read16_queue.push_back(0);     // dummy first transfer16
+    SPI.read16_queue.push_back(avail); // avail from spiRd16_fast
+    std::vector<uint8_t> data(avail + 2, 0);
+    uint8_t* p = data.data() + 2;
+    uint32_t len = avail;
+    p[0] = len & 0xFF;
+    p[1] = (len >> 8) & 0xFF;
+    p[2] = (len >> 16) & 0xFF;
+    p[3] = (len >> 24) & 0xFF;
+    p[4] = 0xAA;
+    p[5] = 0xAA;
+    p[6] = 0xAA;
+    p[7] = 0xAA;
+    p[8] = frame_len & 0xFF;
+    p[9] = (frame_len >> 8) & 0xFF;
+    for (int i = 0; i < frame_len; ++i) {
+        p[RX_HDR + i] = static_cast<uint8_t>(i + 1);
+    }
+    p[RX_HDR + frame_len] = 0x55;
+    p[RX_HDR + frame_len + 1] = 0x55;
+    for (uint8_t b : data)
+        SPI.read_queue.push_back(b);
+
+    fetchRx();
+    uint8_t out[64] = {0};
+    size_t got = spiQCA7000checkForReceivedData(out, sizeof(out));
+    ASSERT_EQ(got, frame_len);
+    for (int i = 0; i < frame_len; ++i) {
+        EXPECT_EQ(out[i], static_cast<uint8_t>(i + 1));
+    }
+}

--- a/tests/stubs/Arduino.h
+++ b/tests/stubs/Arduino.h
@@ -1,0 +1,20 @@
+#ifndef ARDUINO_H_STUB
+#define ARDUINO_H_STUB
+#include <stdint.h>
+#define LOW    0
+#define HIGH   1
+#define OUTPUT 1
+inline void digitalWrite(int, int) {
+}
+inline void pinMode(int, int) {
+}
+inline unsigned long millis() {
+    return 0;
+}
+inline void delay(unsigned long) {
+}
+inline void noInterrupts() {
+}
+inline void interrupts() {
+}
+#endif

--- a/tests/stubs/SPI.cpp
+++ b/tests/stubs/SPI.cpp
@@ -1,0 +1,2 @@
+#include "SPI.h"
+SPIClass SPI;

--- a/tests/stubs/SPI.h
+++ b/tests/stubs/SPI.h
@@ -1,0 +1,49 @@
+#ifndef SPI_H_STUB
+#define SPI_H_STUB
+#include <deque>
+#include <stdint.h>
+#include <vector>
+#define MSBFIRST  1
+#define SPI_MODE3 3
+class SPISettings {
+public:
+    SPISettings(uint32_t, uint8_t, uint8_t) {
+    }
+};
+
+class SPIClass {
+public:
+    std::deque<uint16_t> read16_queue;
+    std::deque<uint8_t> read_queue;
+    std::vector<uint8_t> written;
+    std::vector<uint16_t> transferred16;
+    std::vector<uint8_t> transferred;
+    void begin() {
+    }
+    void beginTransaction(const SPISettings&) {
+    }
+    void endTransaction() {
+    }
+    uint16_t transfer16(uint16_t v) {
+        transferred16.push_back(v);
+        if (read16_queue.empty())
+            return 0;
+        uint16_t r = read16_queue.front();
+        read16_queue.pop_front();
+        return r;
+    }
+    uint8_t transfer(uint8_t v) {
+        transferred.push_back(v);
+        if (read_queue.empty())
+            return 0;
+        uint8_t r = read_queue.front();
+        read_queue.pop_front();
+        return r;
+    }
+    void writeBytes(const uint8_t* d, size_t l) {
+        written.insert(written.end(), d, d + l);
+    }
+};
+
+extern SPIClass SPI;
+#endif

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -1,0 +1,5 @@
+#ifndef ESP_LOG_H_STUB
+#define ESP_LOG_H_STUB
+#define ESP_LOGE(tag, fmt, ...)
+#define ESP_LOGI(tag, fmt, ...)
+#endif

--- a/tests/stubs/esp_system.h
+++ b/tests/stubs/esp_system.h
@@ -1,0 +1,7 @@
+#ifndef ESP_SYSTEM_H_STUB
+#define ESP_SYSTEM_H_STUB
+#include <stdint.h>
+static inline uint32_t esp_random() {
+    return 0x42u;
+}
+#endif


### PR DESCRIPTION
## Summary
- expose `txFrame` and `fetchRx` for tests and stub ESP headers when not on ESP
- add stub Arduino/SPI headers for host testing
- add new tests verifying `fetchRx` frame extraction and `txFrame` formatting
- integrate new tests in CMake

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `cmake --build .`
- `ctest -V`

------
https://chatgpt.com/codex/tasks/task_e_688205067ee48324a9c2380dd059ffdd