### PR TITLE
Remove unused test and add NMK-HS check

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }

--- a/tests/libslac_unit_test.cpp
+++ b/tests/libslac_unit_test.cpp
@@ -47,9 +47,6 @@ private:
     uint8_t mac_addr[ETH_ALEN]{0};
 };
 
-TEST_F(LibSLACUnitTest, test_invalid_datetime) {
-    ASSERT_TRUE(1 == 1);
-}
 
 TEST_F(LibSLACUnitTest, test_generate_nid_from_nmk_check_security_bits) {
     uint8_t nid[slac::defs::NID_LEN] = {0};
@@ -58,6 +55,16 @@ TEST_F(LibSLACUnitTest, test_generate_nid_from_nmk_check_security_bits) {
 
     slac::utils::generate_nid_from_nmk(nid, sample_nmk);
     ASSERT_TRUE((nid[6] >> 4) == 0x00);
+}
+
+TEST_F(LibSLACUnitTest, test_generate_nmk_hs_known_password) {
+    const char password[] = "test";
+    uint8_t nmk_hs[slac::defs::NMK_LEN] = {0};
+    const uint8_t expected[] = {0x3f, 0x94, 0x65, 0x6f, 0xa8, 0x20, 0x42, 0x42,
+                                0xa0, 0x90, 0x26, 0xc7, 0x93, 0x9f, 0x1f, 0xc5};
+
+    slac::utils::generate_nmk_hs(nmk_hs, password, strlen(password));
+    ASSERT_EQ(memcmp(nmk_hs, expected, slac::defs::NMK_LEN), 0);
 }
 
 TEST_F(LibSLACUnitTest, test_channel_read_sets_length) {


### PR DESCRIPTION
## Summary
- remove the dummy `test_invalid_datetime`
- add a unit test for `generate_nmk_hs`
- define `ESP_LOGW` when building tests so `qca7000.cpp` compiles

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest`

------
https://chatgpt.com/codex/tasks/task_e_68820b7874f483249d8d755fe44d47cf