### PR TITLE
Improve send error handling

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -2,4 +2,5 @@
 #define ESP_LOG_H_STUB
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 #endif

--- a/tools/evse/evse_fsm.cpp
+++ b/tools/evse/evse_fsm.cpp
@@ -62,7 +62,9 @@ EvseFSM::EvseFSM(SlacIO& slac_io) : slac_io(slac_io) {
 
         msg_out.setup_ethernet_header(plc_peer_mac);
 
-        this->slac_io.send(msg_out);
+        if (!this->slac_io.send(msg_out)) {
+            LOG_ERROR("Failed to transmit CM_SET_KEY.REQ\n");
+        }
 
         // wait for CM_SET_KEY.CNF from the PLC. 1s should be plenty of time
         // for the modem to respond.
@@ -170,7 +172,9 @@ EvseFSM::EvseFSM(SlacIO& slac_io) : slac_io(slac_io) {
 
     sd_do_atten_char.entry = [this](FSMInitContextType& ctx) {
         setup_atten_char_ind_message(msg_out, matching_ctx);
-        this->slac_io.send(msg_out);
+        if (!this->slac_io.send(msg_out)) {
+            LOG_ERROR("Failed to transmit CM_ATTEN_CHAR.IND\n");
+        }
         sd_do_atten_char.ind_msg_count = 0; // no retries yet
         ctx.set_next_timeout(slac::defs::TT_MATCH_RESPONSE_MS, true);
     };
@@ -183,7 +187,9 @@ EvseFSM::EvseFSM(SlacIO& slac_io) : slac_io(slac_io) {
         }
 
         // resend CM_ATTEN_CHAR.IND
-        this->slac_io.send(msg_out);
+        if (!this->slac_io.send(msg_out)) {
+            LOG_ERROR("Failed to transmit CM_ATTEN_CHAR.IND\n");
+        }
         sd_do_atten_char.ind_msg_count++;
     };
 
@@ -284,7 +290,9 @@ void EvseFSM::sd_wait_for_matching_hsm(FSMContextType& ctx, const EventSlacMessa
     msg_out.setup_payload(&param_confirm, sizeof(param_confirm),
                           slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, slac::defs::MMV::AV_1_0);
 
-    slac_io.send(msg_out);
+    if (!slac_io.send(msg_out)) {
+        LOG_ERROR("Failed to transmit CM_SLAC_PARAM.CNF\n");
+    }
 
     ctx.submit_event(EventStartMatching());
 }
@@ -393,7 +401,9 @@ void EvseFSM::sd_wait_for_slac_match_hsm(FSMContextType& ctx, const EventSlacMes
         msg_out.setup_ethernet_header(msg_in.get_src_mac());
         msg_out.setup_payload(&cnf, sizeof(cnf), slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_CNF,
                               slac::defs::MMV::AV_1_0);
-        slac_io.send(msg_out);
+        if (!slac_io.send(msg_out)) {
+            LOG_ERROR("Failed to transmit CM_VALIDATE.CNF\n");
+        }
         return;
     }
 
@@ -428,7 +438,9 @@ void EvseFSM::sd_wait_for_slac_match_hsm(FSMContextType& ctx, const EventSlacMes
     msg_out.setup_payload(&match_cnf, sizeof(match_cnf), slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF,
                           slac::defs::MMV::AV_1_0);
 
-    slac_io.send(msg_out);
+    if (!slac_io.send(msg_out)) {
+        LOG_ERROR("Failed to transmit CM_SLAC_MATCH.CNF\n");
+    }
 
     ctx.set_next_timeout(slac::defs::TT_MATCH_JOIN_MS);
 }
@@ -446,7 +458,9 @@ void EvseFSM::sd_reset_hsm(FSMContextType& ctx, const EventSlacMessage& ev) {
         msg_out.setup_ethernet_header(msg_in.get_src_mac());
         msg_out.setup_payload(&cnf, sizeof(cnf), slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_CNF,
                               slac::defs::MMV::AV_1_0);
-        slac_io.send(msg_out);
+        if (!slac_io.send(msg_out)) {
+            LOG_ERROR("Failed to transmit CM_VALIDATE.CNF\n");
+        }
         return;
     }
 

--- a/tools/evse/slac_io.cpp
+++ b/tools/evse/slac_io.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include "slac_io.hpp"
+#include "../logging.hpp"
 #ifdef ESP_PLATFORM
 #include <port/esp32s3/qca7000_link.hpp>
 #else
@@ -81,7 +82,10 @@ void SlacIO::process(int timeout_ms) {
     }
 }
 
-void SlacIO::send(slac::messages::HomeplugMessage& msg) {
-    // FIXME (aw): handle errors
-    slac_channel.write(msg, 1);
+bool SlacIO::send(slac::messages::HomeplugMessage& msg) {
+    bool ok = slac_channel.write(msg, 1);
+    if (!ok) {
+        LOG_ERROR("Failed to send SLAC message\n");
+    }
+    return ok;
 }

--- a/tools/evse/slac_io.hpp
+++ b/tools/evse/slac_io.hpp
@@ -44,7 +44,7 @@ public:
     /// incoming messages. This is intended for use when run() was called with
     /// spawn_background set to false.
     void process(int timeout_ms = 10);
-    void send(slac::messages::HomeplugMessage& msg);
+    bool send(slac::messages::HomeplugMessage& msg);
     void quit();
 
 private:


### PR DESCRIPTION
## Summary
- handle send result and log errors
- define ESP_LOGW for host tests
- expose send status to callers
- adapt EVSE FSM to check send result

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68820b809af0832495adcecdaf8a206b