### PR TITLE
Update third-party info

### DIFF
--- a/THIRD_PARTY.rst
+++ b/THIRD_PARTY.rst
@@ -1,0 +1,17 @@
+Third-Party Software
+====================
+
+This project bundles small utility libraries under ``3rd_party``. Each entry below lists the
+upstream source, commit used in this repository and the applicable license.
+
+hash_library
+------------
+* **Version**: commit 9463f3a3a24f9c4b9b4af0e9bae1568ec13357a3
+* **Origin**: https://github.com/stbrumme/hash-library
+* **License**: zlib
+
+libfsm
+------
+* **Version**: commit a09a9a600dc8767b78a6b503b7d80d706cee194e
+* **Origin**: https://github.com/EVerest/libfsm
+* **License**: Apache-2.0

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }


### PR DESCRIPTION
## Summary
- document vendored 3rd_party components
- stub out ESP_LOGW macro for tests

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68820b6a973483249a0e0f7bfb02af9f