### PR TITLE
Avoid heap allocations for ESP32

### DIFF
--- a/pio_src/main.cpp
+++ b/pio_src/main.cpp
@@ -5,15 +5,12 @@
 #include <port/esp32s3/qca7000_link.hpp>
 
 #ifdef ARDUINO
-static slac::port::Qca7000Link* g_link = nullptr;
-static slac::Channel* channel = nullptr;
-
 void setup() {
     static const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
-    g_link = new slac::port::Qca7000Link(cfg);
-    channel = new slac::Channel(g_link);
-    channel->open();
+    static slac::port::Qca7000Link link(cfg);
+    static slac::Channel channel(&link);
+    channel.open();
 }
 
 void loop() {


### PR DESCRIPTION
## Summary
- replace dynamic allocation in `pio_src/main.cpp` with static instances
- initialize `Qca7000Link` and `Channel` inside `setup()`

## Testing
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_68820bcc24e483249be16cb230bd0dda