### PR TITLE
Add generic port config header

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -8,6 +8,8 @@
 
 #ifdef ESP_PLATFORM
 #include "port/esp32s3/port_config.hpp"
+#else
+#include "../../port/generic/port_config.hpp"
 #endif
 #include "sha256.h"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ target_include_directories(slac PRIVATE
 
 target_include_directories(slac PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,16 @@ When :func:`channel.open()` fails, the link enters an error state and further
 calls will not attempt to reinitialise the modem.  Call
 ``link.init_failed()`` to query this condition and react accordingly.
 
+Custom Port Configuration
+-------------------------
+
+The library ships with ``port/generic/port_config.hpp`` providing weak
+implementations for ``slac_millis``, ``slac_delay`` and the interrupt helpers.
+To adapt these functions to a new platform create ``port/<target>/port_config.hpp``
+and add that directory to your compiler include paths.  The ESP32 port in
+``port/esp32s3`` shows how a platform specific header can override the generic
+defaults.
+
 QCA7000 Configuration
 ---------------------
 

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -3,9 +3,7 @@
 #ifndef SLAC_CHANNEL_HPP
 #define SLAC_CHANNEL_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <slac/transport.hpp>
 #include <string>

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -3,9 +3,7 @@
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -1,9 +1,7 @@
 #ifndef SLAC_TRANSPORT_HPP
 #define SLAC_TRANSPORT_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <cstdint>
 #include <cstddef>

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -1,6 +1,8 @@
 #ifndef SLAC_PORT_CONFIG_HPP
 #define SLAC_PORT_CONFIG_HPP
 
+#include "../generic/port_config.hpp"
+
 #include <stdint.h>
 
 #ifdef ESP_PLATFORM
@@ -33,14 +35,6 @@ static inline void slac_noInterrupts() {
 static inline void slac_interrupts() {
     portENABLE_INTERRUPTS();
 }
-#else
-#ifdef ARDUINO
-#include <Arduino.h>
-#endif
-#define slac_millis       millis
-#define slac_delay(ms)    delay(ms)
-#define slac_noInterrupts noInterrupts
-#define slac_interrupts   interrupts
 #endif
 
 #endif // SLAC_PORT_CONFIG_HPP

--- a/port/generic/port_config.hpp
+++ b/port/generic/port_config.hpp
@@ -1,0 +1,23 @@
+#ifndef SLAC_GENERIC_PORT_CONFIG_HPP
+#define SLAC_GENERIC_PORT_CONFIG_HPP
+
+#include <stdint.h>
+#include <chrono>
+#include <thread>
+
+// Weak default implementations for platforms without a custom port_config.hpp
+
+__attribute__((weak)) static inline uint32_t slac_millis() {
+    using namespace std::chrono;
+    static const auto start = steady_clock::now();
+    return static_cast<uint32_t>(duration_cast<milliseconds>(steady_clock::now() - start).count());
+}
+
+__attribute__((weak)) static inline void slac_delay(uint32_t ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+__attribute__((weak)) static inline void slac_noInterrupts() {}
+__attribute__((weak)) static inline void slac_interrupts() {}
+
+#endif // SLAC_GENERIC_PORT_CONFIG_HPP

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include <slac/channel.hpp>
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <algorithm>
 #include <cassert>

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include <slac/slac.hpp>
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <algorithm>
 #include <cassert>


### PR DESCRIPTION
## Summary
- add a new generic `port_config.hpp`
- use the generic header in common sources
- include repo root during CMake builds
- update ESP32 config to override the generic defaults
- document how to provide custom port configuration

## Testing
- `cmake .. -G Ninja`
- `ninja`

------
https://chatgpt.com/codex/tasks/task_e_68820bf6afb0832481f41362b47d382c