### PR TITLE
Add generic port configuration

### DIFF
--- a/3rd_party/CMakeLists.txt
+++ b/3rd_party/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(HashLibrary OBJECT
 
 target_include_directories(HashLibrary PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../port/generic>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
 )
 
 # header-only libfsm

--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -6,9 +6,7 @@
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 #include "sha256.h"
 
 // big endian architectures need #define __BYTE_ORDER __BIG_ENDIAN

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,8 @@ target_include_directories(slac PRIVATE
 
 target_include_directories(slac PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/port/generic>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
 )
 

--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,18 @@ creating :class:`slac::port::Qca7000Link`:
    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
    slac::port::Qca7000Link link(cfg);
 
+Custom Port Configuration
+------------------------
+
+The header ``port/generic/port_config.hpp`` provides weak default
+implementations of timing and interrupt helpers used throughout the
+library. Targets can supply their own ``port_config.hpp`` to override
+these functions.  For example the ESP32 port ships with
+``port/esp32s3/port_config.hpp`` which replaces the generic helpers with
+FreeRTOS based versions.  Place your custom header in a ``port/<target>``
+directory and ensure it is included before the generic one or define the
+macros manually when building.
+
 Tools and Examples
 ------------------
 

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -3,9 +3,7 @@
 #ifndef SLAC_CHANNEL_HPP
 #define SLAC_CHANNEL_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <slac/transport.hpp>
 #include <string>

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -3,9 +3,7 @@
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <cstdint>
 #include <utility>

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -1,9 +1,7 @@
 #ifndef SLAC_TRANSPORT_HPP
 #define SLAC_TRANSPORT_HPP
 
-#ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
-#endif
+#include "port/generic/port_config.hpp"
 
 #include <cstdint>
 #include <cstddef>

--- a/port/esp32s3/ethernet_defs.hpp
+++ b/port/esp32s3/ethernet_defs.hpp
@@ -1,6 +1,7 @@
 #ifndef SLAC_ETHERNET_DEFS_HPP
 #define SLAC_ETHERNET_DEFS_HPP
 
+#include "../generic/port_config.hpp"
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
 #endif

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -1,9 +1,11 @@
 #ifndef SLAC_PORT_CONFIG_HPP
 #define SLAC_PORT_CONFIG_HPP
 
-#include <stdint.h>
+#include "../generic/port_config.hpp"
 
 #ifdef ESP_PLATFORM
+#include <stdint.h>
+
 static inline uint16_t le16toh(uint16_t v) {
     return v;
 }
@@ -21,6 +23,7 @@ static inline uint32_t htole32(uint32_t v) {
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
 #include <freertos/task.h>
+
 static inline uint32_t slac_millis() {
     return (uint32_t)(esp_timer_get_time() / 1000ULL);
 }
@@ -33,14 +36,6 @@ static inline void slac_noInterrupts() {
 static inline void slac_interrupts() {
     portENABLE_INTERRUPTS();
 }
-#else
-#ifdef ARDUINO
-#include <Arduino.h>
-#endif
-#define slac_millis       millis
-#define slac_delay(ms)    delay(ms)
-#define slac_noInterrupts noInterrupts
-#define slac_interrupts   interrupts
-#endif
+#endif // ESP_PLATFORM
 
 #endif // SLAC_PORT_CONFIG_HPP

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1,4 +1,5 @@
 #include "qca7000.hpp"
+#include "../generic/port_config.hpp"
 #include "port_config.hpp"
 #ifdef ESP_PLATFORM
 #include <esp_log.h>
@@ -8,6 +9,7 @@
 #include <arpa/inet.h>
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "../generic/port_config.hpp"
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
 #endif

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -1,4 +1,5 @@
 #include "qca7000_link.hpp"
+#include "../generic/port_config.hpp"
 #include "port_config.hpp"
 #include "qca7000.hpp"
 

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -1,6 +1,7 @@
 #ifndef SLAC_QCA7000_LINK_HPP
 #define SLAC_QCA7000_LINK_HPP
 
+#include "../generic/port_config.hpp"
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
 #endif

--- a/port/generic/port_config.hpp
+++ b/port/generic/port_config.hpp
@@ -1,0 +1,50 @@
+#ifndef SLAC_GENERIC_PORT_CONFIG_HPP
+#define SLAC_GENERIC_PORT_CONFIG_HPP
+
+#include <stdint.h>
+
+#ifdef ARDUINO
+#include <Arduino.h>
+#else
+#include <chrono>
+#include <thread>
+#endif
+
+#ifndef slac_millis
+#ifdef ARDUINO
+#define slac_millis millis
+#else
+static inline uint32_t slac_millis() {
+    using namespace std::chrono;
+    return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+#endif
+#endif
+
+#ifndef slac_delay
+#ifdef ARDUINO
+#define slac_delay(ms) delay(ms)
+#else
+static inline void slac_delay(uint32_t ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+#endif
+#endif
+
+#ifndef slac_noInterrupts
+#ifdef ARDUINO
+#define slac_noInterrupts noInterrupts
+#else
+static inline void slac_noInterrupts() {}
+#endif
+#endif
+
+#ifndef slac_interrupts
+#ifdef ARDUINO
+#define slac_interrupts interrupts
+#else
+static inline void slac_interrupts() {}
+#endif
+#endif
+
+#endif // SLAC_GENERIC_PORT_CONFIG_HPP

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -2,7 +2,7 @@
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include <slac/channel.hpp>
 #ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
+#include "port/generic/port_config.hpp"
 #endif
 
 #include <algorithm>

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -2,7 +2,7 @@
 // Copyright 2022 - 2022 Pionix GmbH and Contributors to EVerest
 #include <slac/slac.hpp>
 #ifdef ESP_PLATFORM
-#include "port/esp32s3/port_config.hpp"
+#include "port/generic/port_config.hpp"
 #endif
 
 #include <algorithm>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,8 @@ target_include_directories(slac_unit_test PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../tools/evse
     ${CMAKE_CURRENT_SOURCE_DIR}/stubs
     ${CMAKE_CURRENT_SOURCE_DIR}/../port/esp32s3
+    ${CMAKE_CURRENT_SOURCE_DIR}/../port/generic
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
 )
 
 target_link_libraries(slac_unit_test PRIVATE


### PR DESCRIPTION
## Summary
- add a generic `port_config.hpp` providing default timing and interrupt helpers
- refactor ESP32 port to include the generic header and override the helpers
- switch library includes to the new generic header
- document how to supply a custom port configuration

## Testing
- `cmake .. -DBUILD_TESTING=ON`
- `cmake --build .`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_68820bf6afb0832481f41362b47d382c