### PR TITLE
Add UART link implementation and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,12 +51,19 @@ set(SLAC_SOURCES
     src/channel.cpp
     src/slac.cpp
 )
+option(SLAC_USE_UART "Use UART interface for QCA7000" OFF)
 
 if (ESP_PLATFORM)
-    list(APPEND SLAC_SOURCES
-        port/esp32s3/qca7000_link.cpp
-        port/esp32s3/qca7000.cpp
-    )
+    if (SLAC_USE_UART)
+        list(APPEND SLAC_SOURCES
+            port/esp32s3/qca7000_uart.cpp
+        )
+    else()
+        list(APPEND SLAC_SOURCES
+            port/esp32s3/qca7000_link.cpp
+            port/esp32s3/qca7000.cpp
+        )
+    endif()
 else()
     list(APPEND SLAC_SOURCES
         src/packet_socket.cpp
@@ -65,6 +72,9 @@ else()
 endif()
 
 target_sources(slac PRIVATE ${SLAC_SOURCES} $<TARGET_OBJECTS:HashLibrary>)
+if (SLAC_USE_UART)
+    target_compile_definitions(slac PUBLIC SLAC_USE_UART)
+endif()
 
 if (ESP_PLATFORM)
     target_include_directories(slac PRIVATE port/esp32s3)

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,3 +9,12 @@ build_unflags = -std=gnu++11
 build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
 src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>
+
+[env:esp32s3-uart]
+platform = espressif32@6.5.0
+board = esp32-s3-devkitc-1
+framework = arduino
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -DSLAC_USE_UART -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+lib_ldf_mode = chain
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000_uart.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -8,6 +8,7 @@
 #include <arpa/inet.h>
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }
@@ -137,6 +138,7 @@ static bool hardReset() {
         return false;
     }
     ESP_LOGI(PLC_TAG, "Reset probe OK (SIG=0x%04X)", sig);
+#define ESP_LOGW(tag, fmt, ...)
 
     t0 = slac_millis();
     while (!(slowRd16(SPI_REG_INTR_CAUSE) & SPI_INT_CPU_ON) && slac_millis() - t0 < 80)
@@ -342,6 +344,7 @@ void qca7000Process() {
 
 bool qca7000setup(SPIClass* bus, int csPin) {
     ESP_LOGI(PLC_TAG, "QCA7000 setup: bus=%p CS=%d", bus, csPin);
+#define ESP_LOGW(tag, fmt, ...)
     g_spi = bus;
     g_cs = csPin;
     if (g_spi)
@@ -356,6 +359,7 @@ bool qca7000setup(SPIClass* bus, int csPin) {
 
     spiWr16_fast(SPI_REG_INTR_ENABLE, INTR_MASK);
     ESP_LOGI(PLC_TAG, "QCA7000 ready");
+#define ESP_LOGW(tag, fmt, ...)
     return true;
 }
 

--- a/port/esp32s3/qca7000_uart.cpp
+++ b/port/esp32s3/qca7000_uart.cpp
@@ -1,0 +1,264 @@
+#include "qca7000_uart.hpp"
+#include "port_config.hpp"
+#ifdef ESP_PLATFORM
+#include <esp_log.h>
+#else
+#define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
+#define ESP_LOGE(tag, fmt, ...)
+#endif
+#include <string.h>
+
+#ifdef LIBSLAC_TESTING
+static const char* PLC_TAG = "PLC_IF";
+#else
+const char* PLC_TAG = "PLC_IF";
+#endif
+
+#ifdef LIBSLAC_TESTING
+static uint8_t myethtransmitbuffer[V2GTP_BUFFER_SIZE]{};
+static size_t myethtransmitlen = 0;
+static uint8_t myethreceivebuffer[V2GTP_BUFFER_SIZE]{};
+static size_t myethreceivelen = 0;
+#else
+uint8_t myethtransmitbuffer[V2GTP_BUFFER_SIZE]{};
+size_t myethtransmitlen = 0;
+uint8_t myethreceivebuffer[V2GTP_BUFFER_SIZE]{};
+size_t myethreceivelen = 0;
+#endif
+
+
+static constexpr uint16_t SOF_WORD = 0xAAAA;
+static constexpr uint16_t EOF_WORD = 0x5555;
+static constexpr uint16_t TX_HDR = 8;
+static constexpr uint16_t RX_HDR = 8;
+static constexpr uint16_t FTR_LEN = 2;
+
+#ifdef LIBSLAC_TESTING
+HardwareSerial* g_serial = nullptr;
+#else
+static HardwareSerial* g_serial = nullptr;
+#endif
+
+namespace {
+struct RxEntry {
+    size_t len;
+    uint8_t data[V2GTP_BUFFER_SIZE];
+};
+static RxEntry ring[4];
+static volatile uint8_t head = 0, tail = 0;
+inline bool ringEmpty() { return head == tail; }
+inline void ringPush(const uint8_t* d, size_t l) {
+    slac_noInterrupts();
+    if (l > V2GTP_BUFFER_SIZE)
+        l = V2GTP_BUFFER_SIZE;
+    uint8_t next = (head + 1) & 3;
+    if (next == tail) {
+        slac_interrupts();
+        ESP_LOGW(PLC_TAG, "RX ring full - dropping frame");
+        return;
+    }
+    memcpy(ring[head].data, d, l);
+    ring[head].len = l;
+    head = next;
+    slac_interrupts();
+}
+inline bool ringPop(const uint8_t** d, size_t* l) {
+    slac_noInterrupts();
+    if (ringEmpty()) {
+        slac_interrupts();
+        return false;
+    }
+    *d = ring[tail].data;
+    *l = ring[tail].len;
+    tail = (tail + 1) & 3;
+    slac_interrupts();
+    return true;
+}
+
+static enum State { WAIT_SOF, LEN1, LEN2, RSVD1, RSVD2, PAYLOAD, EOF1, EOF2 } state = WAIT_SOF;
+static size_t sof_count = 0;
+static uint16_t rx_len = 0;
+static uint16_t rx_pos = 0;
+static uint8_t rx_buf[V2GTP_BUFFER_SIZE];
+
+inline void processByte(uint8_t b) {
+    switch (state) {
+    case WAIT_SOF:
+        if (b == 0xAA) {
+            if (++sof_count == 4) {
+                sof_count = 0;
+                state = LEN1;
+            }
+        } else {
+            sof_count = 0;
+        }
+        break;
+    case LEN1:
+        rx_len = b;
+        state = LEN2;
+        break;
+    case LEN2:
+        rx_len |= static_cast<uint16_t>(b) << 8;
+        if (rx_len > V2GTP_BUFFER_SIZE) {
+            state = WAIT_SOF;
+            break;
+        }
+        state = RSVD1;
+        break;
+    case RSVD1:
+        state = RSVD2;
+        break;
+    case RSVD2:
+        rx_pos = 0;
+        state = PAYLOAD;
+        break;
+    case PAYLOAD:
+        rx_buf[rx_pos++] = b;
+        if (rx_pos >= rx_len)
+            state = EOF1;
+        break;
+    case EOF1:
+        if (b == 0x55)
+            state = EOF2;
+        else
+            state = WAIT_SOF;
+        break;
+    case EOF2:
+        if (b == 0x55)
+            ringPush(rx_buf, rx_len);
+        state = WAIT_SOF;
+        break;
+    }
+}
+
+inline void pollRx() {
+    while (g_serial && g_serial->available()) {
+        int v = g_serial->read();
+        if (v < 0)
+            break;
+        processByte(static_cast<uint8_t>(v));
+    }
+}
+} // namespace
+
+#ifdef LIBSLAC_TESTING
+bool uartTxFrame(const uint8_t* eth, size_t ethLen) {
+#else
+static bool uartTxFrame(const uint8_t* eth, size_t ethLen) {
+#endif
+    if (!g_serial || ethLen > 1522)
+        return false;
+    size_t frameLen = ethLen;
+    if (frameLen < 60)
+        frameLen = 60;
+    uint8_t hdr[TX_HDR];
+    hdr[0] = hdr[1] = hdr[2] = hdr[3] = 0xAA;
+    hdr[4] = frameLen & 0xFF;
+    hdr[5] = (frameLen >> 8) & 0xFF;
+    hdr[6] = 0;
+    hdr[7] = 0;
+    g_serial->write(hdr, TX_HDR);
+    if (ethLen)
+        g_serial->write(eth, ethLen);
+    if (frameLen > ethLen) {
+        uint8_t pad[60]{};
+        g_serial->write(pad, frameLen - ethLen);
+    }
+    uint8_t eof[2] = {0x55, 0x55};
+    g_serial->write(eof, 2);
+    return true;
+}
+
+#ifdef LIBSLAC_TESTING
+void uartFetchRx() {
+#else
+static void uartFetchRx() {
+#endif
+    pollRx();
+}
+
+bool uartQCA7000SendEthFrame(const uint8_t* f, size_t l) {
+    bool ok = uartTxFrame(f, l);
+    if (ok && l <= V2GTP_BUFFER_SIZE) {
+        memcpy(myethtransmitbuffer, f, l);
+        myethtransmitlen = l;
+    }
+    return ok;
+}
+
+size_t uartQCA7000checkForReceivedData(uint8_t* d, size_t m) {
+    pollRx();
+    const uint8_t* s;
+    size_t l;
+    if (!ringPop(&s, &l))
+        return 0;
+    size_t c = l > m ? m : l;
+    memcpy(d, s, c);
+    size_t store = l > V2GTP_BUFFER_SIZE ? V2GTP_BUFFER_SIZE : l;
+    memcpy(myethreceivebuffer, s, store);
+    myethreceivelen = l;
+    return c;
+}
+
+namespace slac {
+namespace port {
+
+Qca7000UartLink::Qca7000UartLink(const qca7000_uart_config& c) : cfg(c) {
+    memset(mac_addr, 0, sizeof(mac_addr));
+}
+
+bool Qca7000UartLink::open() {
+    if (initialized)
+        return true;
+    if (initialization_error)
+        return false;
+
+    g_serial = cfg.serial ? cfg.serial : &Serial;
+#ifdef ARDUINO
+    if (g_serial)
+        g_serial->begin(cfg.baud ? cfg.baud : 115200);
+#endif
+    if (cfg.mac_addr)
+        memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);
+    else {
+        const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+        memcpy(mac_addr, def_mac, ETH_ALEN);
+    }
+    initialized = true;
+    return true;
+}
+
+bool Qca7000UartLink::write(const uint8_t* b, size_t l, uint32_t) {
+    if (!initialized || initialization_error)
+        return false;
+    return uartQCA7000SendEthFrame(b, l);
+}
+
+bool Qca7000UartLink::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
+    if (!initialized || initialization_error) {
+        *out = 0;
+        return false;
+    }
+    uint32_t start = slac_millis();
+    do {
+        size_t got = uartQCA7000checkForReceivedData(b, l);
+        if (got) {
+            *out = got;
+            return true;
+        }
+        if (timeout_ms == 0)
+            break;
+        slac_delay(1);
+    } while (slac_millis() - start < timeout_ms);
+    *out = 0;
+    return false;
+}
+
+const uint8_t* Qca7000UartLink::mac() const {
+    return mac_addr;
+}
+
+} // namespace port
+} // namespace slac
+

--- a/port/esp32s3/qca7000_uart.hpp
+++ b/port/esp32s3/qca7000_uart.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#ifdef ESP_PLATFORM
+#include "port_config.hpp"
+#endif
+
+#include "ethernet_defs.hpp"
+#ifndef V2GTP_BUFFER_SIZE
+#define V2GTP_BUFFER_SIZE 1536
+#endif
+#include <slac/transport.hpp>
+
+#ifdef ARDUINO
+#include <HardwareSerial.h>
+#endif
+
+struct qca7000_uart_config {
+    HardwareSerial* serial;
+    uint32_t baud;
+    const uint8_t* mac_addr{nullptr};
+};
+
+namespace slac {
+namespace port {
+
+class Qca7000UartLink : public transport::Link {
+public:
+    explicit Qca7000UartLink(const qca7000_uart_config& cfg);
+
+    bool open() override;
+    bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    bool read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
+    const uint8_t* mac() const override;
+
+    bool init_failed() const { return initialization_error; }
+    bool is_initialized() const { return initialized; }
+
+private:
+    bool initialized{false};
+    bool initialization_error{false};
+    qca7000_uart_config cfg;
+    uint8_t mac_addr[ETH_ALEN]{};
+};
+
+} // namespace port
+} // namespace slac

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,10 +2,12 @@ add_executable(slac_unit_test
     libslac_unit_test.cpp
     evse_fsm_test.cpp
     qca7000_test.cpp
+    qca7000_uart_test.cpp
     ../tools/evse/evse_fsm.cpp
     ../tools/evse/slac_io.cpp
     ../tools/evse/packet_socket_link.cpp
     stubs/SPI.cpp
+    stubs/HardwareSerial.cpp
 )
 
 find_package(GTest REQUIRED)

--- a/tests/qca7000_uart_test.cpp
+++ b/tests/qca7000_uart_test.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#define LIBSLAC_TESTING
+#define ARDUINO
+#include "../port/esp32s3/qca7000_uart.cpp"
+#include "stubs/HardwareSerial.h"
+#include <endian.h>
+
+class QCA7000UartTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        g_serial = &Serial;
+        Serial.read_queue.clear();
+        Serial.written.clear();
+    }
+};
+
+TEST_F(QCA7000UartTest, txFramePaddingAndMarkers) {
+    uint8_t frame[4] = {1, 2, 3, 4};
+    bool ok = uartTxFrame(frame, sizeof(frame));
+    ASSERT_TRUE(ok);
+    ASSERT_EQ(Serial.written.size(), TX_HDR + 60 + FTR_LEN);
+    EXPECT_EQ(Serial.written[0], 0xAA);
+    EXPECT_EQ(Serial.written[1], 0xAA);
+    EXPECT_EQ(Serial.written[2], 0xAA);
+    EXPECT_EQ(Serial.written[3], 0xAA);
+    EXPECT_EQ(*reinterpret_cast<uint16_t*>(&Serial.written[4]), htole16(60));
+    EXPECT_EQ(Serial.written[TX_HDR + 60], 0x55);
+    EXPECT_EQ(Serial.written[TX_HDR + 61], 0x55);
+}
+
+TEST_F(QCA7000UartTest, fetchRxExtractsFrame) {
+    const uint16_t frame_len = 20;
+    Serial.read_queue.clear();
+    for (int i = 0; i < 4; ++i)
+        Serial.read_queue.push_back(0xAA);
+    Serial.read_queue.push_back(frame_len & 0xFF);
+    Serial.read_queue.push_back((frame_len >> 8) & 0xFF);
+    Serial.read_queue.push_back(0);
+    Serial.read_queue.push_back(0);
+    for (int i = 0; i < frame_len; ++i)
+        Serial.read_queue.push_back(static_cast<uint8_t>(i + 1));
+    Serial.read_queue.push_back(0x55);
+    Serial.read_queue.push_back(0x55);
+
+    uartFetchRx();
+    uint8_t out[64] = {0};
+    size_t got = uartQCA7000checkForReceivedData(out, sizeof(out));
+    ASSERT_EQ(got, frame_len);
+    for (int i = 0; i < frame_len; ++i)
+        EXPECT_EQ(out[i], static_cast<uint8_t>(i + 1));
+}

--- a/tests/stubs/HardwareSerial.cpp
+++ b/tests/stubs/HardwareSerial.cpp
@@ -1,0 +1,2 @@
+#include "HardwareSerial.h"
+HardwareSerial Serial;

--- a/tests/stubs/HardwareSerial.h
+++ b/tests/stubs/HardwareSerial.h
@@ -1,0 +1,26 @@
+#ifndef HARDWARE_SERIAL_STUB_H
+#define HARDWARE_SERIAL_STUB_H
+#include <deque>
+#include <stdint.h>
+#include <vector>
+class HardwareSerial {
+public:
+    std::deque<uint8_t> read_queue;
+    std::vector<uint8_t> written;
+    void begin(unsigned long) {}
+    size_t write(const uint8_t* d, size_t l) {
+        written.insert(written.end(), d, d + l);
+        return l;
+    }
+    int available() { return read_queue.size(); }
+    int read() {
+        if (read_queue.empty())
+            return -1;
+        uint8_t v = read_queue.front();
+        read_queue.pop_front();
+        return v;
+    }
+};
+
+extern HardwareSerial Serial;
+#endif

--- a/tests/stubs/esp_log.h
+++ b/tests/stubs/esp_log.h
@@ -2,4 +2,5 @@
 #define ESP_LOG_H_STUB
 #define ESP_LOGE(tag, fmt, ...)
 #define ESP_LOGI(tag, fmt, ...)
+#define ESP_LOGW(tag, fmt, ...)
 #endif


### PR DESCRIPTION
## Summary
- implement UART-based `Qca7000UartLink` and helpers
- allow selecting UART via `SLAC_USE_UART` option
- add PlatformIO env for UART
- provide serial stubs and unit tests for UART framing
- define missing `ESP_LOGW` stub

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `ctest --test-dir build -j $(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_68820bdbd21883249be0f6764636cdd2