### PR TITLE
Add reset pin config and polling docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ An example for the ESP32-S3 port:
    #include <port/esp32s3/qca7000_link.hpp>
 
    const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-   qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+   qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, my_mac};
    slac::port::Qca7000Link link(cfg);
    slac::Channel channel(&link);
    if (!channel.open()) {
@@ -112,16 +112,37 @@ QCA7000 Configuration
 
 The SPI pins used to communicate with the QCA7000 modem are defined in
 ``port/esp32s3/qca7000.hpp`` as ``PLC_SPI_CS_PIN`` and ``PLC_SPI_RST_PIN``.
-Override these macros when building to match your hardware wiring.
+Override these macros when building to match your hardware wiring or
+specify the pins through ``qca7000_config`` when opening the link.
 
-The modem's MAC address can be specified via ``qca7000_config`` when
-creating :class:`slac::port::Qca7000Link`:
+The ``qca7000_config`` struct allows selecting the SPI bus, chip select
+and reset pins as well as the modem's MAC address when creating
+``slac::port::Qca7000Link``:
 
 .. code-block:: cpp
 
    const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-   qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+   qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, my_mac};
    slac::port::Qca7000Link link(cfg);
+
+Polling Operation
+-----------------
+
+``libslac`` does not require the QCA7000 interrupt pin. Call
+``qca7000Process()`` regularly to poll the modem for new frames. This
+works on boards where the interrupt line is not connected.
+
+UART Mode
+---------
+
+If ``SLAC_USE_UART`` is defined, ``libslac`` provides
+``slac::port::Qca7000UartLink``. Select the serial port and baud rate
+via ``qca7000_uart_config``:
+
+.. code-block:: cpp
+
+   qca7000_uart_config cfg{&Serial2, 1250000};
+   slac::port::Qca7000UartLink link(cfg);
 
 Custom Port Configuration
 ------------------------
@@ -138,7 +159,7 @@ macros manually when building.
 Tools and Examples
 ------------------
 
-The ``tools`` directory contains small utilities demonstrating how to use ``libslac``. ``tools/evse`` contains a simple state machine for the EVSE side of the SLAC handshake. ``tools/bridge.cpp`` can forward packets between two virtual interfaces on Linux and is disabled on microcontroller builds.
+The ``tools`` directory contains small utilities demonstrating how to use ``libslac``. ``tools/evse`` contains a simple state machine for the EVSE side of the SLAC handshake. ``tools/bridge.cpp`` can forward packets between two virtual interfaces on Linux and is disabled on microcontroller builds. See ``docs/BoardExample.md`` for a complete PlatformIO configuration using custom pins.
 
 Porting to Other Boards
 -----------------------

--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -1,0 +1,37 @@
+# ESP32-S3 DevKit Board Example
+
+This example demonstrates how to wire the QCA7000 modem to an
+ESP32-S3 board using PlatformIO. The board uses custom SPI pins and
+operates the modem without connecting the optional interrupt line.
+
+## PlatformIO configuration
+
+```ini
+[env:esp32-s3-devkitc-1]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+board_build.partitions = default_8MB.csv
+board_upload.flash_size = 8MB
+board_build.arduino.memory_type = dio_qspi
+build_flags = \
+    -DPLC_SPI_CS_PIN=41 \
+    -DPLC_SPI_RST_PIN=40
+```
+
+The SPI bus is started with the custom pins in `setup()`:
+
+```cpp
+SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, 41 /*CS*/);
+qca7000_config cfg{&SPI, 41, 40, my_mac};
+slac::port::Qca7000Link link(cfg);
+while (true) {
+    qca7000Process();
+    // application tasks
+}
+```
+
+No interrupt pin is used. The loop above shows how the modem can be
+polled without relying on an external IRQ line.

--- a/pio_src/main.cpp
+++ b/pio_src/main.cpp
@@ -7,13 +7,13 @@
 #ifdef ARDUINO
 void setup() {
     static const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, my_mac};
     static slac::port::Qca7000Link link(cfg);
     static slac::Channel channel(&link);
     channel.open();
 }
 
 void loop() {
-    // placeholder main loop
+    qca7000Process();
 }
 #endif

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -60,10 +60,11 @@
 struct qca7000_config {
     SPIClass* spi;
     int cs_pin;
+    int rst_pin{PLC_SPI_RST_PIN};
     const uint8_t* mac_addr{nullptr};
 };
 
-bool qca7000setup(SPIClass* spi, int cs_pin);
+bool qca7000setup(SPIClass* spi, int cs_pin, int rst_pin = PLC_SPI_RST_PIN);
 bool qca7000ResetAndCheck();
 uint16_t qca7000ReadInternalReg(uint8_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -18,8 +18,9 @@ bool Qca7000Link::open() {
 
     SPIClass* bus = cfg.spi ? cfg.spi : &SPI;
     int cs = cfg.cs_pin ? cfg.cs_pin : PLC_SPI_CS_PIN;
+    int rst = cfg.rst_pin ? cfg.rst_pin : PLC_SPI_RST_PIN;
 
-    if (!qca7000setup(bus, cs)) {
+    if (!qca7000setup(bus, cs, rst)) {
         initialization_error = true;
         return false;
     }


### PR DESCRIPTION
## Summary
- allow configuring the QCA7000 reset pin at runtime
- document how to use libslac without the interrupt line
- update PlatformIO example and add board-specific sample

## Testing
- `cmake -S . -B build -DBUILD_TESTING=ON`
- `cmake --build build`
- `cd build && ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6882112ea3508324a64516f8effce0c7