### PR TITLE
Add QCA7000 polling example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -123,6 +123,26 @@ creating :class:`slac::port::Qca7000Link`:
    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
    slac::port::Qca7000Link link(cfg);
 
+Polling Without IRQ
+-------------------
+
+The QCA7000 driver can be polled instead of relying on an interrupt
+line.  The ``pio_src/polling_example.cpp`` example calls
+``qca7000Process()`` from the ``loop()`` function and then polls the
+channel for new packets.  When using this approach the IRQ pin on the
+modem may remain unconnected.
+
+.. code-block:: cpp
+
+   void loop() {
+       qca7000Process();
+       slac::messages::HomeplugMessage msg;
+       if (channel.poll(msg)) {
+           // handle message
+       }
+       delay(1);
+   }
+
 Custom Port Configuration
 ------------------------
 

--- a/pio_src/polling_example.cpp
+++ b/pio_src/polling_example.cpp
@@ -1,0 +1,28 @@
+#ifdef ARDUINO
+#include <Arduino.h>
+#endif
+#include <slac/channel.hpp>
+#include <port/esp32s3/qca7000.hpp>
+#include <port/esp32s3/qca7000_link.hpp>
+
+#ifdef ARDUINO
+static slac::Channel* g_channel = nullptr;
+
+void setup() {
+    static const uint8_t my_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, my_mac};
+    static slac::port::Qca7000Link link(cfg);
+    static slac::Channel channel(&link);
+    g_channel = &channel;
+    channel.open();
+}
+
+void loop() {
+    qca7000Process();
+    slac::messages::HomeplugMessage msg;
+    if (g_channel && g_channel->poll(msg)) {
+        // handle incoming packet
+    }
+    delay(1);
+}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -18,3 +18,12 @@ build_unflags = -std=gnu++11
 build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -DSLAC_USE_UART -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
 src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000_uart.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/main.cpp>
+
+[env:esp32s3-poll]
+platform = espressif32@6.5.0
+board = esp32-s3-devkitc-1
+framework = arduino
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+lib_ldf_mode = chain
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/polling_example.cpp>


### PR DESCRIPTION
## Summary
- add example showing how to poll QCA7000 without IRQ
- expose new `esp32s3-poll` environment for PlatformIO
- document optional IRQ usage in README

## Testing
- `cmake .. -G Ninja -DBUILD_TESTING=ON`
- `ninja`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6882147f703883249e974f968b3882c1