### PR TITLE
Add esp32 board example for PlatformIO

### DIFF
--- a/examples/esp32_board_example/platformio.ini
+++ b/examples/esp32_board_example/platformio.ini
@@ -1,0 +1,17 @@
+[platformio]
+src_dir = src
+
+[env:esp32-s3-devkitc-1]
+platform = espressif32
+board = esp32-s3-devkitc-1
+framework = arduino
+monitor_speed = 115200
+monitor_filters = esp32_exception_decoder
+board_build.partitions = default_8MB.csv
+board_upload.flash_size = 8MB
+board_build.arduino.memory_type = dio_qspi
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17 -I../.. -I../../include -I../../3rd_party -I../../port/esp32s3 -DESP_PLATFORM -DPLC_SPI_CS_PIN=41 -DPLC_SPI_RST_PIN=40 -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti
+lib_ldf_mode = chain
+lib_deps = SPI
+build_src_filter = +<src/main.cpp> +<../../src/channel.cpp> +<../../src/slac.cpp> +<../../3rd_party/hash_library/sha256.cpp> +<../../port/esp32s3/qca7000.cpp> +<../../port/esp32s3/qca7000_link.cpp>

--- a/examples/esp32_board_example/src/main.cpp
+++ b/examples/esp32_board_example/src/main.cpp
@@ -1,0 +1,25 @@
+#include <Arduino.h>
+#include <slac/channel.hpp>
+#include <port/esp32s3/qca7000_link.hpp>
+
+static const uint8_t MY_MAC[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+static slac::Channel* g_channel = nullptr;
+
+void setup() {
+    Serial.begin(115200);
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
+    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
+    static slac::port::Qca7000Link link(cfg);
+    static slac::Channel channel(&link);
+    g_channel = &channel;
+    channel.open();
+}
+
+void loop() {
+    qca7000Process();
+    slac::messages::HomeplugMessage msg;
+    if (g_channel && g_channel->poll(msg)) {
+        // handle incoming SLAC messages
+    }
+    delay(1);
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -27,3 +27,12 @@ build_unflags = -std=gnu++11
 build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
 lib_ldf_mode = chain
 src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<pio_src/polling_example.cpp>
+
+[env:esp32s3-board]
+platform = espressif32@6.5.0
+board = esp32-s3-devkitc-1
+framework = arduino
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -DPLC_SPI_CS_PIN=41 -DPLC_SPI_RST_PIN=40 -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+lib_ldf_mode = chain
+src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<examples/esp32_board_example/src/main.cpp>

--- a/port/generic/port_config.hpp
+++ b/port/generic/port_config.hpp
@@ -11,9 +11,9 @@
 #endif
 
 #ifndef slac_millis
-#ifdef ARDUINO
+#if defined(ARDUINO) && !defined(ESP_PLATFORM)
 #define slac_millis millis
-#else
+#elif !defined(ARDUINO)
 static inline uint32_t slac_millis() {
     using namespace std::chrono;
     return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
@@ -22,9 +22,9 @@ static inline uint32_t slac_millis() {
 #endif
 
 #ifndef slac_delay
-#ifdef ARDUINO
+#if defined(ARDUINO) && !defined(ESP_PLATFORM)
 #define slac_delay(ms) delay(ms)
-#else
+#elif !defined(ARDUINO)
 static inline void slac_delay(uint32_t ms) {
     std::this_thread::sleep_for(std::chrono::milliseconds(ms));
 }
@@ -32,17 +32,17 @@ static inline void slac_delay(uint32_t ms) {
 #endif
 
 #ifndef slac_noInterrupts
-#ifdef ARDUINO
+#if defined(ARDUINO) && !defined(ESP_PLATFORM)
 #define slac_noInterrupts noInterrupts
-#else
+#elif !defined(ARDUINO)
 static inline void slac_noInterrupts() {}
 #endif
 #endif
 
 #ifndef slac_interrupts
-#ifdef ARDUINO
+#if defined(ARDUINO) && !defined(ESP_PLATFORM)
 #define slac_interrupts interrupts
-#else
+#elif !defined(ARDUINO)
 static inline void slac_interrupts() {}
 #endif
 #endif


### PR DESCRIPTION
## Summary
- add an ESP32-S3 PlatformIO example with custom SPI pins
- make Arduino port config play well with ESP-IDF builds
- support board build via new `esp32s3-board` environment

## Testing
- `pio run -e esp32s3-board`


------
https://chatgpt.com/codex/tasks/task_e_688229b74be4832491a1207c4f5688d6