### PR TITLE
Fix Windows macro detection for sha256

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -72,7 +72,7 @@ inline uint32_t swap(uint32_t x) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
 #endif
-#ifdef MSC_VER
+#ifdef _MSC_VER
     return _byteswap_ulong(x);
 #endif
 


### PR DESCRIPTION
## Summary
- fix MSVC detection macro in `sha256.cpp`

## Testing
- `platformio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_688252dd0f948324bf1d9cd3c68566c6