### PR TITLE
Handle timeouts when link read fails

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -36,9 +36,11 @@ bool Channel::read(slac::messages::HomeplugMessage& msg, int timeout) {
         return false;
 
     size_t out_len = 0;
-    bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()), sizeof(messages::homeplug_message),
+    bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()),
+                         sizeof(messages::homeplug_message),
                          &out_len, timeout);
     if (!ok) {
+        did_timeout = timeout > 0;
         return false;
     }
 
@@ -56,9 +58,12 @@ bool Channel::poll(slac::messages::HomeplugMessage& msg) {
         return false;
 
     size_t out_len = 0;
-    bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()), sizeof(messages::homeplug_message),
-                         &out_len, 0);
+    const int timeout = 0;
+    bool ok = link->read(reinterpret_cast<uint8_t*>(msg.get_raw_message_ptr()),
+                         sizeof(messages::homeplug_message),
+                         &out_len, timeout);
     if (!ok) {
+        did_timeout = timeout > 0;
         return false;
     }
 


### PR DESCRIPTION
## Summary
- mark Channel timeout when link->read fails

## Testing
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_688254673e248324bd505ddcfaa7b614