### PR TITLE
Fix assert message in Channel write

### DIFF
--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -76,7 +76,7 @@ bool Channel::poll(slac::messages::HomeplugMessage& msg) {
 }
 
 bool Channel::write(slac::messages::HomeplugMessage& msg, int timeout) {
-    assert(("Homeplug message is not valid\n", msg.is_valid()));
+    assert(msg.is_valid() && "Homeplug message is not valid");
     did_timeout = false;
 
     if (!link)


### PR DESCRIPTION
## Summary
- fix assert usage in `Channel::write`

## Testing
- `platformio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_68825bf407848324808bdd780c7ee72c