### PR TITLE
Add generic timing helpers for non-ESP/Arduino builds

### DIFF
--- a/port/port_common.hpp
+++ b/port/port_common.hpp
@@ -1,7 +1,10 @@
 #ifndef SLAC_GENERIC_PORT_CONFIG_HPP
 #define SLAC_GENERIC_PORT_CONFIG_HPP
 
+#include <chrono>
+#include <mutex>
 #include <stdint.h>
+#include <thread>
 
 #ifdef ARDUINO
 #include <Arduino.h>
@@ -9,25 +12,62 @@
 
 #ifndef slac_millis
 #if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline uint32_t slac_millis() { return millis(); }
+static inline uint32_t slac_millis() {
+    return millis();
+}
+#elif !defined(ESP_PLATFORM)
+static inline uint32_t slac_millis() {
+    using namespace std::chrono;
+    return (uint32_t)duration_cast<milliseconds>(steady_clock::now().time_since_epoch()).count();
+}
+#else
+#error "slac_millis() not defined for this platform"
 #endif
 #endif
 
 #ifndef slac_delay
 #if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_delay(uint32_t ms) { delay(ms); }
+static inline void slac_delay(uint32_t ms) {
+    delay(ms);
+}
+#elif !defined(ESP_PLATFORM)
+static inline void slac_delay(uint32_t ms) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+#else
+#error "slac_delay() not defined for this platform"
 #endif
 #endif
 
 #ifndef slac_noInterrupts
 #if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_noInterrupts() { noInterrupts(); }
+static inline void slac_noInterrupts() {
+    noInterrupts();
+}
+#elif !defined(ESP_PLATFORM)
+static inline std::mutex& slac_mutex() {
+    static std::mutex m;
+    return m;
+}
+static inline void slac_noInterrupts() {
+    slac_mutex().lock();
+}
+#else
+#error "slac_noInterrupts() not defined for this platform"
 #endif
 #endif
 
 #ifndef slac_interrupts
 #if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_interrupts() { interrupts(); }
+static inline void slac_interrupts() {
+    interrupts();
+}
+#elif !defined(ESP_PLATFORM)
+static inline void slac_interrupts() {
+    slac_mutex().unlock();
+}
+#else
+#error "slac_interrupts() not defined for this platform"
 #endif
 #endif
 


### PR DESCRIPTION
## Summary
- support non-ESP/Arduino environments
- implement timing and critical-section helpers using `std::chrono` and `std::mutex`

## Testing
- `g++ -std=c++17 -Iinclude -I3rd_party -I. -c src/slac.cpp -o /tmp/slac.o`

------
https://chatgpt.com/codex/tasks/task_e_688269ea32488324981b4c8d2c37847c