### PR TITLE
Check result of channel.open()

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -20,7 +20,12 @@ void setup() {
     static slac::port::Qca7000Link link(cfg);
     static slac::Channel channel(&link);
     g_channel = &channel;
-    channel.open();
+    if (!channel.open()) {
+        Serial.println("Failed to open SLAC channel, aborting");
+        g_channel = nullptr;
+        while (true)
+            delay(1000);
+    }
 }
 
 void loop() {


### PR DESCRIPTION
## Summary
- bail out if `channel.open()` fails in the PlatformIO example

## Testing
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_68826bd0680c83249ce00aeae29620b7