### PR TITLE
Add log macro guards

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -5,11 +5,17 @@
 #include <esp_log.h>
 #include <esp_system.h>
 #else
-#include <stdint.h>
 #include <arpa/inet.h>
+#include <stdint.h>
+#ifndef ESP_LOGE
 #define ESP_LOGE(tag, fmt, ...)
+#endif
+#ifndef ESP_LOGI
 #define ESP_LOGI(tag, fmt, ...)
+#endif
+#ifndef ESP_LOGW
 #define ESP_LOGW(tag, fmt, ...)
+#endif
 static inline uint32_t esp_random() {
     return 0x12345678u;
 }
@@ -141,7 +147,9 @@ static bool hardReset() {
         return false;
     }
     ESP_LOGI(PLC_TAG, "Reset probe OK (SIG=0x%04X)", sig);
+#ifndef ESP_LOGW
 #define ESP_LOGW(tag, fmt, ...)
+#endif
 
     t0 = slac_millis();
     while (!(slowRd16(SPI_REG_INTR_CAUSE) & SPI_INT_CPU_ON) && slac_millis() - t0 < 80)
@@ -347,7 +355,9 @@ void qca7000Process() {
 
 bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
     ESP_LOGI(PLC_TAG, "QCA7000 setup: bus=%p CS=%d RST=%d", bus, csPin, rstPin);
+#ifndef ESP_LOGW
 #define ESP_LOGW(tag, fmt, ...)
+#endif
     g_spi = bus;
     g_cs = csPin;
     g_rst = rstPin;
@@ -363,7 +373,9 @@ bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
 
     spiWr16_fast(SPI_REG_INTR_ENABLE, INTR_MASK);
     ESP_LOGI(PLC_TAG, "QCA7000 ready");
+#ifndef ESP_LOGW
 #define ESP_LOGW(tag, fmt, ...)
+#endif
     return true;
 }
 

--- a/port/esp32s3/qca7000_uart.cpp
+++ b/port/esp32s3/qca7000_uart.cpp
@@ -4,9 +4,15 @@
 #ifdef ESP_PLATFORM
 #include <esp_log.h>
 #else
+#ifndef ESP_LOGI
 #define ESP_LOGI(tag, fmt, ...)
+#endif
+#ifndef ESP_LOGW
 #define ESP_LOGW(tag, fmt, ...)
+#endif
+#ifndef ESP_LOGE
 #define ESP_LOGE(tag, fmt, ...)
+#endif
 #endif
 #include <string.h>
 


### PR DESCRIPTION
## Summary
- avoid warning from redefining ESP_LOG macros in qca7000.cpp
- avoid warning from redefining ESP_LOG macros in qca7000_uart.cpp

## Testing
- `g++ -std=c++17 -Iinclude -I. -Iport -Iport/esp32s3 -I3rd_party -c port/esp32s3/qca7000.cpp -o /tmp/qca7000.o` *(fails: 'SPIClass' does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68826bd541a88324837f853a3097d572