### PR TITLE
Fix endian header selection

### DIFF
--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -12,6 +12,18 @@
 #include <arpa/inet.h>
 #if defined(ESP_PLATFORM) && !defined(__GLIBC__)
 #include "port/esp32s3/endian_compat.hpp"
+#elif defined(__has_include)
+#  if __has_include(<endian.h>)
+#    include <endian.h>
+#  elif defined(__APPLE__)
+#    if __has_include(<machine/endian.h>)
+#      include <machine/endian.h>
+#    else
+#      include <libkern/OSByteOrder.h>
+#    endif
+#  elif __has_include(<machine/endian.h>)
+#    include <machine/endian.h>
+#  endif
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
## Summary
- improve endian header detection in `src/slac.cpp`

## Testing
- `g++ -c -std=c++17 src/slac.cpp -Iinclude -I. -Iport -Iport/esp32s3 -I3rd_party`
- `g++ -c -std=c++17 src/channel.cpp -Iinclude -I. -Iport -Iport/esp32s3 -I3rd_party`


------
https://chatgpt.com/codex/tasks/task_e_68826c3d4f44832488e2712623b34a4b