### PR TITLE
Adjust cmd16 register argument handling

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -87,7 +87,8 @@ inline bool ringPop(const uint8_t** d, size_t* l) {
 } // namespace
 
 static inline uint16_t cmd16(bool rd, bool intr, uint16_t reg) {
-    return (rd ? 0x8000u : 0) | (intr ? 0x4000u : 0) | (reg & 0x3FFFu);
+    return (rd ? 0x8000u : 0) | (intr ? 0x4000u : 0) |
+           (((reg << 8) & 0x3FFFu));
 }
 
 static uint16_t spiRd16_fast(uint16_t reg) {
@@ -151,11 +152,12 @@ static bool hardReset() {
     return true;
 }
 
-uint16_t qca7000ReadInternalReg(uint8_t r) {
-    return spiRd16_fast(r << 8);
+uint16_t qca7000ReadInternalReg(uint16_t r) {
+    return spiRd16_fast(r);
 }
 bool qca7000ReadSignature(uint16_t* s, uint16_t* v) {
-    uint16_t sig = qca7000ReadInternalReg(0x1A), ver = qca7000ReadInternalReg(0x1B);
+    uint16_t sig = qca7000ReadInternalReg(SPI_REG_SIGNATURE),
+             ver = qca7000ReadInternalReg(0x1B);
     if (s)
         *s = sig;
     if (v)

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -32,22 +32,22 @@
 #define SPI_INT_WRBUF_ERR 0x0004
 #endif
 #ifndef SPI_REG_SIGNATURE
-#define SPI_REG_SIGNATURE 0x1A00
+#define SPI_REG_SIGNATURE 0x1A
 #endif
 #ifndef SPI_REG_WRBUF_SPC_AVA
-#define SPI_REG_WRBUF_SPC_AVA 0x0200
+#define SPI_REG_WRBUF_SPC_AVA 0x02
 #endif
 #ifndef SPI_REG_INTR_CAUSE
-#define SPI_REG_INTR_CAUSE 0x0C00
+#define SPI_REG_INTR_CAUSE 0x0C
 #endif
 #ifndef SPI_REG_BFR_SIZE
-#define SPI_REG_BFR_SIZE 0x0100
+#define SPI_REG_BFR_SIZE 0x01
 #endif
 #ifndef SPI_REG_RDBUF_BYTE_AVA
-#define SPI_REG_RDBUF_BYTE_AVA 0x0300
+#define SPI_REG_RDBUF_BYTE_AVA 0x03
 #endif
 #ifndef SPI_REG_INTR_ENABLE
-#define SPI_REG_INTR_ENABLE 0x0D00
+#define SPI_REG_INTR_ENABLE 0x0D
 #endif
 
 #ifndef PLC_SPI_RST_PIN
@@ -66,7 +66,7 @@ struct qca7000_config {
 
 bool qca7000setup(SPIClass* spi, int cs_pin, int rst_pin = PLC_SPI_RST_PIN);
 bool qca7000ResetAndCheck();
-uint16_t qca7000ReadInternalReg(uint8_t reg);
+uint16_t qca7000ReadInternalReg(uint16_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);


### PR DESCRIPTION
## Summary
- shift register address inside `cmd16`
- use unshifted register constants
- update register read helper and signature read

## Testing
- `platformio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_68826c474810832494d38e8a92a7900b