### PR TITLE
Propagate read timeout status through Channel

### DIFF
--- a/examples/platformio_complete/test/test_basic.cpp
+++ b/examples/platformio_complete/test/test_basic.cpp
@@ -4,12 +4,16 @@
 
 class DummyLink : public slac::transport::Link {
 public:
-    bool open() override { return true; }
-    bool write(const uint8_t*, size_t, uint32_t) override { return true; }
-    bool read(uint8_t*, size_t, size_t* out_len, uint32_t) override {
+    bool open() override {
+        return true;
+    }
+    bool write(const uint8_t*, size_t, uint32_t) override {
+        return true;
+    }
+    slac::transport::LinkError read(uint8_t*, size_t, size_t* out_len, uint32_t) override {
         if (out_len)
             *out_len = 0;
-        return true;
+        return slac::transport::LinkError::Ok;
     }
     const uint8_t* mac() const override {
         static const uint8_t mac[6] = {0};

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -30,7 +30,7 @@ public:
     ~Channel();
 
     bool open();
-    bool read(slac::messages::HomeplugMessage& msg, int timeout);
+    transport::LinkError read(slac::messages::HomeplugMessage& msg, int timeout);
     bool poll(slac::messages::HomeplugMessage& msg);
     bool write(slac::messages::HomeplugMessage& msg, int timeout);
 

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -3,15 +3,22 @@
 
 #include "port/port_common.hpp"
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 
 namespace slac::transport {
+
+enum class LinkError {
+    Ok,
+    Timeout,
+    Transport,
+};
+
 class Link {
 public:
     virtual bool open() = 0;
     virtual bool write(const uint8_t* buf, size_t len, uint32_t timeout_ms) = 0;
-    virtual bool read(uint8_t* buf, size_t len, size_t* out_len, uint32_t timeout_ms) = 0;
+    virtual LinkError read(uint8_t* buf, size_t len, size_t* out_len, uint32_t timeout_ms) = 0;
     virtual const uint8_t* mac() const = 0;
     virtual ~Link() = default;
 };

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -42,24 +42,24 @@ bool Qca7000Link::write(const uint8_t* b, size_t l, uint32_t) {
     return spiQCA7000SendEthFrame(b, l);
 }
 
-bool Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
+transport::LinkError Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) {
     if (!initialized || initialization_error) {
         *out = 0;
-        return false;
+        return transport::LinkError::Transport;
     }
     uint32_t start = slac_millis();
     do {
         size_t got = spiQCA7000checkForReceivedData(b, l);
         if (got) {
             *out = got;
-            return true;
+            return transport::LinkError::Ok;
         }
         if (timeout_ms == 0)
             break;
         slac_delay(1);
     } while (slac_millis() - start < timeout_ms);
     *out = 0;
-    return false;
+    return transport::LinkError::Timeout;
 }
 
 const uint8_t* Qca7000Link::mac() const {

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -19,7 +19,7 @@ public:
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
-    bool read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
+    transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 
     /**

--- a/port/esp32s3/qca7000_uart.hpp
+++ b/port/esp32s3/qca7000_uart.hpp
@@ -29,11 +29,15 @@ public:
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
-    bool read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
+    transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 
-    bool init_failed() const { return initialization_error; }
-    bool is_initialized() const { return initialized; }
+    bool init_failed() const {
+        return initialization_error;
+    }
+    bool is_initialized() const {
+        return initialized;
+    }
 
 private:
     bool initialized{false};


### PR DESCRIPTION
## Summary
- add `LinkError` enumeration to transport layer
- return `LinkError` from Link::read and Channel::read
- adapt Qca7000 link implementations to new return type
- update example dummy link and Channel interface

## Testing
- `g++ -std=c++17 -Iinclude -Iport -I. -I3rd_party -c src/channel.cpp -o /tmp/channel.o`
- `g++ -std=c++17 -Iinclude -Iport -I. -I3rd_party -c src/slac.cpp -o /tmp/slac.o`
- `g++ -std=c++17 -Iinclude -Iport -I. -I3rd_party -c 3rd_party/hash_library/sha256.cpp -o /tmp/sha256.o`
- `g++ -std=c++17 -Iinclude -Iport -I. -I3rd_party examples/platformio_complete/test/test_basic.cpp /tmp/channel.o /tmp/slac.o /tmp/sha256.o -o /tmp/test_prog`
- `/tmp/test_prog`

------
https://chatgpt.com/codex/tasks/task_e_688275caf7e4832498ddfe1cf7ab9a0f