### PR TITLE
Include intrin.h for MSVC

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -10,6 +10,10 @@
 #include "sha256.h"
 #include <cstring>
 
+#ifdef _MSC_VER
+#    include <intrin.h>
+#endif
+
 #include <slac/endian.hpp>
 
 // #define SHA2_224_SEED_VECTOR


### PR DESCRIPTION
## Summary
- include `<intrin.h>` when building sha256 on Windows

## Testing
- `git show --stat -1`

------
https://chatgpt.com/codex/tasks/task_e_68827b36c7008324b086df975076cc84