### PR TITLE
Add unit tests and runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *build
 *build-cross
+tests_run

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+CXXFLAGS="-std=c++17 -DNDEBUG -Iinclude -I3rd_party -Iport/esp32s3 -Iport -I."
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp src/channel.cpp src/slac.cpp 3rd_party/hash_library/sha256.cpp"
+
+#g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run
+
+g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run
+./tests_run

--- a/tests/test_channel.cpp
+++ b/tests/test_channel.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+#include <slac/channel.hpp>
+#include <slac/slac.hpp>
+#include <vector>
+#include <cstring>
+
+class MockLink : public slac::transport::Link {
+public:
+    bool open() override { return true; }
+    bool write(const uint8_t* b, size_t l, uint32_t) override {
+        tx.assign(b, b + l);
+        rx = tx;
+        return true;
+    }
+    slac::transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t) override {
+        if (rx.empty()) {
+            if (out)
+                *out = 0;
+            return slac::transport::LinkError::Timeout;
+        }
+        size_t copy = std::min(l, rx.size());
+        memcpy(b, rx.data(), copy);
+        rx.clear();
+        if (out)
+            *out = copy;
+        return slac::transport::LinkError::Ok;
+    }
+    const uint8_t* mac() const override { return MAC; }
+    static inline uint8_t MAC[6] = {0x02,0,0,0,0,1};
+    std::vector<uint8_t> tx;
+    std::vector<uint8_t> rx;
+};
+
+TEST(Channel, RoundTrip) {
+    MockLink link;
+    slac::Channel channel(&link);
+    ASSERT_TRUE(channel.open());
+
+    slac::messages::HomeplugMessage msg;
+    slac::messages::cm_slac_parm_req req{};
+    req.application_type = 0;
+    req.security_type = 0;
+    memset(req.run_id, 0, sizeof(req.run_id));
+
+    ASSERT_TRUE(msg.setup_payload(&req, sizeof(req),
+                                  slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_REQ,
+                                  slac::defs::MMV::AV_1_0));
+    uint8_t dst[ETH_ALEN] = {0xff,0xff,0xff,0xff,0xff,0xff};
+    msg.setup_ethernet_header(dst);
+
+    ASSERT_TRUE(channel.write(msg, 100));
+
+    slac::messages::HomeplugMessage in;
+    auto err = channel.read(in, 100);
+    ASSERT_EQ(err, slac::transport::LinkError::Ok);
+    EXPECT_EQ(in.get_mmtype(), msg.get_mmtype());
+    EXPECT_EQ(in.get_raw_msg_len(), msg.get_raw_msg_len());
+    EXPECT_EQ(0, memcmp(in.get_raw_message_ptr(), msg.get_raw_message_ptr(), msg.get_raw_msg_len()));
+}

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -1,0 +1,20 @@
+#include <gtest/gtest.h>
+#include <slac/endian.hpp>
+
+TEST(Endian, Swap) {
+    EXPECT_EQ(slac_bswap16(0x1234u), 0x3412u);
+    EXPECT_EQ(slac_bswap32(0x11223344u), 0x44332211u);
+    EXPECT_EQ(slac_bswap64(0x1122334455667788ull), 0x8877665544332211ull);
+}
+
+TEST(Endian, HostLE) {
+    uint16_t v16 = 0xA1B2u;
+    uint32_t v32 = 0xA1B2C3D4u;
+    uint64_t v64 = 0x1122334455667788ull;
+    EXPECT_EQ(htole16(v16), v16);
+    EXPECT_EQ(le16toh(v16), v16);
+    EXPECT_EQ(htole32(v32), v32);
+    EXPECT_EQ(le32toh(v32), v32);
+    EXPECT_EQ(htole64(v64), v64);
+    EXPECT_EQ(le64toh(v64), v64);
+}

--- a/tests/test_payload.cpp
+++ b/tests/test_payload.cpp
@@ -1,0 +1,44 @@
+#include <gtest/gtest.h>
+#include <slac/slac.hpp>
+#include <cstring>
+
+using namespace slac;
+
+TEST(Payload, BuildAV10) {
+    messages::HomeplugMessage msg;
+    uint8_t payload[10];
+    for (int i = 0; i < 10; ++i)
+        payload[i] = i;
+
+    ASSERT_TRUE(msg.setup_payload(payload, sizeof(payload), 0x1234, defs::MMV::AV_1_0));
+    EXPECT_TRUE(msg.is_valid());
+    EXPECT_EQ(msg.get_mmtype(), 0x1234);
+    EXPECT_EQ(msg.get_raw_msg_len(), defs::MME_MIN_LENGTH);
+
+    auto raw = msg.get_raw_message_ptr();
+    EXPECT_EQ(raw->homeplug_header.mmv, static_cast<uint8_t>(defs::MMV::AV_1_0));
+    EXPECT_EQ(memcmp(raw->payload, payload, sizeof(payload)), 0);
+}
+
+TEST(Payload, BuildAV20Frag) {
+    messages::HomeplugMessage msg;
+    uint8_t payload[8];
+    for (int i = 0; i < 8; ++i)
+        payload[i] = i + 1;
+
+    ASSERT_TRUE(msg.setup_payload(payload, sizeof(payload), 0x4321, defs::MMV::AV_2_0));
+    auto raw = msg.get_raw_message_ptr();
+    EXPECT_EQ(raw->homeplug_header.mmv, static_cast<uint8_t>(defs::MMV::AV_2_0));
+    const messages::homeplug_fragmentation_part* frag =
+        reinterpret_cast<const messages::homeplug_fragmentation_part*>(raw->payload);
+    EXPECT_EQ(frag->fmni, 0);
+    EXPECT_EQ(frag->fmsn, 0);
+    EXPECT_EQ(memcmp(raw->payload + sizeof(*frag), payload, sizeof(payload)), 0);
+}
+
+TEST(Payload, TooLong) {
+    messages::HomeplugMessage msg;
+    const size_t big_len = sizeof(messages::homeplug_message::payload) + 1;
+    std::vector<uint8_t> big(big_len, 0);
+    EXPECT_FALSE(msg.setup_payload(big.data(), big.size(), 0x1000, defs::MMV::AV_1_0));
+}

--- a/tests/test_sha256.cpp
+++ b/tests/test_sha256.cpp
@@ -1,0 +1,10 @@
+#include <gtest/gtest.h>
+#include <hash_library/sha256.h>
+
+TEST(SHA256, KnownVectors) {
+    SHA256 sha;
+    EXPECT_EQ(sha("abc"),
+              std::string("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"));
+    EXPECT_EQ(sha(""),
+              std::string("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
+}


### PR DESCRIPTION
## Summary
- add gtest-based unit tests for payload handling, endian helpers, SHA‑256 vectors and channel logic
- provide a shell script to build and run the tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68827d86aae08324887f34a4ade32eee