### PR TITLE
Validate payload setup failures

### DIFF
--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -81,8 +81,9 @@ static constexpr auto effective_payload_length(const defs::MMV mmv) {
 bool HomeplugMessage::setup_payload(void const* payload, int len, uint16_t mmtype, const defs::MMV mmv) {
     const auto max_len = effective_payload_length(mmv);
     if (len > max_len) {
-        // keep previous state and signal the failure
+        // mark the message invalid and signal the failure
         assert(("Homeplug Payload length too long", len <= max_len));
+        raw_msg_len = -1;
         return false;
     }
     raw_msg.homeplug_header.mmv = static_cast<std::underlying_type_t<defs::MMV>>(mmv);
@@ -147,7 +148,7 @@ void HomeplugMessage::set_raw_msg_len(int len) {
 }
 
 bool HomeplugMessage::is_valid() const {
-    return raw_msg_len >= defs::MME_MIN_LENGTH;
+    return raw_msg_len >= static_cast<int>(defs::MME_MIN_LENGTH);
 }
 
 } // namespace messages

--- a/tests/test_payload.cpp
+++ b/tests/test_payload.cpp
@@ -41,4 +41,5 @@ TEST(Payload, TooLong) {
     const size_t big_len = sizeof(messages::homeplug_message::payload) + 1;
     std::vector<uint8_t> big(big_len, 0);
     EXPECT_FALSE(msg.setup_payload(big.data(), big.size(), 0x1000, defs::MMV::AV_1_0));
+    EXPECT_FALSE(msg.is_valid());
 }


### PR DESCRIPTION
## Summary
- mark `HomeplugMessage` invalid when `setup_payload` fails
- ensure `is_valid()` checks against signed length
- test invalidation behaviour and failed writes

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688280e60bfc832493035594eee572a7