### PR TITLE
Add fatal error reporting in Qca7000Link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,6 +115,11 @@ When :func:`channel.open()` fails, the link enters an error state and further
 calls will not attempt to reinitialise the modem.  Call
 ``link.init_failed()`` to query this condition and react accordingly.
 
+Unexpected modem resets are reported through an optional callback or
+error flag. Use ``link.set_error_callback(cb, arg)`` to register a
+callback and periodically check ``link.fatal_error()`` when polling the
+driver.
+
 QCA7000 Configuration
 ---------------------
 

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -73,6 +73,9 @@ bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
 uint8_t qca7000getSlacResult();
 void qca7000Process();
+
+typedef void (*qca7000_error_cb_t)(void*);
+void qca7000SetErrorCallback(qca7000_error_cb_t cb, void* arg, bool* flag);
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -15,7 +15,17 @@ namespace port {
 
 class Qca7000Link : public transport::Link {
 public:
-    explicit Qca7000Link(const qca7000_config& cfg);
+    using ErrorCallback = qca7000_error_cb_t;
+
+    explicit Qca7000Link(const qca7000_config& cfg,
+                         ErrorCallback cb = nullptr,
+                         void* cb_arg = nullptr);
+
+    void set_error_callback(ErrorCallback cb, void* arg);
+    bool fatal_error() const { return fatal_error_flag; }
+    void clear_fatal_error() { fatal_error_flag = false; }
+
+    ~Qca7000Link();
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
@@ -39,6 +49,9 @@ public:
 private:
     bool initialized{false};
     bool initialization_error{false};
+    bool fatal_error_flag{false};
+    ErrorCallback error_cb{nullptr};
+    void* error_arg{nullptr};
     qca7000_config cfg;
     uint8_t mac_addr[ETH_ALEN]{};
 };


### PR DESCRIPTION
## Summary
- report modem resets through callback or flag in Qca7000Link
- expose `qca7000SetErrorCallback` and update driver
- document callback usage in README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688280ed9bd8832481c829695b8c4d83