### PR TITLE
Refine PlatformIO configs

### DIFF
--- a/examples/platformio_complete/README.md
+++ b/examples/platformio_complete/README.md
@@ -19,9 +19,7 @@ editing `build_flags` in `platformio.ini`.
 
 ## Testing
 
-A small unit test is provided under `test/` and can be run on the host
-using:
-
-```bash
-pio test -e native
-```
+This example only defines a single PlatformIO environment for the
+ESP32-S3 board.  The unit test under `test/` can be compiled and run
+on the host using a native environment if desired, but that
+configuration is not included by default.

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -7,14 +7,7 @@ platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -DESP_PLATFORM
+build_flags =
+    -std=gnu++17   ; use C++17 standard
+    -DESP_PLATFORM ; target ESP32 platform
 lib_deps = https://github.com/hyndex/libslac.git
-
-[env:native]
-platform = native
-build_flags = -std=gnu++17
-lib_deps = https://github.com/hyndex/libslac.git
-# Include the example source when running tests
-test_framework = custom
-build_src_filter = +<src/main.cpp> +<test/test_basic.cpp>
-test_build_src = yes

--- a/platformio.ini
+++ b/platformio.ini
@@ -6,6 +6,24 @@ platform = espressif32@6.5.0
 board = esp32-s3-devkitc-1
 framework = arduino
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+build_flags =
+    -std=gnu++17             ; use C++17 standard
+    -Iinclude                ; library headers
+    -I3rd_party              ; third-party headers
+    -Iport/esp32s3           ; ESP32-S3 specific headers
+    -DESP_PLATFORM           ; target ESP32 platform
+    -Os                      ; optimise for size
+    -fdata-sections          ; remove unused data sections
+    -ffunction-sections      ; remove unused function sections
+    -fno-exceptions          ; disable C++ exceptions
+    -fno-rtti                ; disable runtime type information
+    -DBUILD_SLAC_TOOLS=OFF   ; skip building extra tools
+    -DBUILD_TESTING=OFF      ; disable tests
 lib_ldf_mode = chain
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<examples/platformio_complete/src/main.cpp>
+src_filter =
+    +<src/channel.cpp>
+    +<src/slac.cpp>
+    +<port/esp32s3/qca7000.cpp>
+    +<port/esp32s3/qca7000_link.cpp>
+    +<3rd_party/hash_library/sha256.cpp>
+    +<examples/platformio_complete/src/main.cpp>


### PR DESCRIPTION
## Summary
- collapse PlatformIO examples to a single environment
- document each flag in the main config
- update example README to explain missing native env

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688287051a908324b8e0fc5cd6e93e35