### PR TITLE
Simplify PlatformIO configuration

### DIFF
--- a/examples/platformio_complete/README.md
+++ b/examples/platformio_complete/README.md
@@ -17,11 +17,3 @@ The project pulls `libslac` automatically via `lib_deps`.
 Custom chip select and reset pins for the modem can be configured by
 editing `build_flags` in `platformio.ini`.
 
-## Testing
-
-A small unit test is provided under `test/` and can be run on the host
-using:
-
-```bash
-pio test -e native
-```

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -6,15 +6,13 @@ test_dir = test
 platform = espressif32
 board = esp32-s3-devkitc-1
 framework = arduino
-build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -DESP_PLATFORM
-lib_deps = https://github.com/hyndex/libslac.git
 
-[env:native]
-platform = native
-build_flags = -std=gnu++17
+; remove the default -std=gnu++11 flag
+build_unflags = -std=gnu++11
+
+; C++17 build and enable ESP platform defines
+build_flags =
+    -std=gnu++17     ; use C++17
+    -DESP_PLATFORM   ; compile for ESP platform
+
 lib_deps = https://github.com/hyndex/libslac.git
-# Include the example source when running tests
-test_framework = custom
-build_src_filter = +<src/main.cpp> +<test/test_basic.cpp>
-test_build_src = yes

--- a/platformio.ini
+++ b/platformio.ini
@@ -2,10 +2,33 @@
 src_dir = .
 
 [env:esp32s3]
-platform = espressif32@6.5.0
-board = esp32-s3-devkitc-1
-framework = arduino
+platform = espressif32@6.5.0 ; use ESP32 toolchain version 6.5.0
+board = esp32-s3-devkitc-1  ; target board
+framework = arduino         ; build using the Arduino core
+
+# remove the default C++11 flag
 build_unflags = -std=gnu++11
-build_flags = -std=gnu++17 -Iinclude -I3rd_party -Iport/esp32s3 -DESP_PLATFORM -Os -fdata-sections -ffunction-sections -fno-exceptions -fno-rtti -DBUILD_SLAC_TOOLS=OFF -DBUILD_TESTING=OFF
+
+# compilation flags
+build_flags =
+    -std=gnu++17                 ; enable C++17
+    -Iinclude                    ; library headers
+    -I3rd_party                  ; third-party sources
+    -Iport/esp32s3               ; board specific port
+    -DESP_PLATFORM               ; enable ESP platform features
+    -Os                          ; optimise for size
+    -fdata-sections              ; remove unused data
+    -ffunction-sections          ; remove unused functions
+    -fno-exceptions              ; disable exceptions
+    -fno-rtti                    ; disable run-time type info
+    -DBUILD_SLAC_TOOLS=OFF       ; omit command line tools
+    -DBUILD_TESTING=OFF          ; disable library tests
+
 lib_ldf_mode = chain
-src_filter = +<src/channel.cpp> +<src/slac.cpp> +<port/esp32s3/qca7000.cpp> +<port/esp32s3/qca7000_link.cpp> +<3rd_party/hash_library/sha256.cpp> +<examples/platformio_complete/src/main.cpp>
+src_filter =
+    +<src/channel.cpp>
+    +<src/slac.cpp>
+    +<port/esp32s3/qca7000.cpp>
+    +<port/esp32s3/qca7000_link.cpp>
+    +<3rd_party/hash_library/sha256.cpp>
+    +<examples/platformio_complete/src/main.cpp>


### PR DESCRIPTION
## Summary
- keep only a single environment in `platformio.ini` files
- explain build flags via comments
- update example README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688287051a908324b8e0fc5cd6e93e35