### PR TITLE
Fix allocator and channel error handling

### DIFF
--- a/3rd_party/fsm/fsm/fsm.hpp
+++ b/3rd_party/fsm/fsm/fsm.hpp
@@ -72,7 +72,14 @@ public:
     FSM(FSM&& other) = delete;
     FSM& operator=(const FSM& other) = delete;
     FSM& operator=(FSM&& other) = delete;
-    ~FSM() = default;
+    ~FSM() {
+        state_allocator.release_staged_states<SimpleStateType, CompoundStateType>();
+        reset();
+    }
+
+    auto allocator_state() const {
+        return state_allocator.get_internal_state();
+    }
 
     template <typename StateType, typename... Args> void reset(Args&&... args) {
         reset();
@@ -210,6 +217,10 @@ public:
     ~FSM() {
         state_allocator.template release_staged_states<SimpleStateType, CompoundStateType>();
         reset();
+    }
+
+    auto allocator_state() const {
+        return state_allocator.get_internal_state();
     }
 
     template <typename StateType, typename... Args> void reset(Args&&... args) {

--- a/3rd_party/fsm/fsm/states.hpp
+++ b/3rd_party/fsm/fsm/states.hpp
@@ -112,6 +112,10 @@ public:
         return success ? State::NEW_STATE : State::ALLOCATION_ERROR;
     }
 
+    auto allocator_state() const {
+        return allocator.get_internal_state();
+    }
+
     // NOTE (aw): this could also be a non-static function, which checks if any states have been set
     static constexpr HandleEventResult PASS_ON{HandleEventResult::InternalState::PASS_ON};
     static constexpr HandleEventResult HANDLED_INTERNALLY{HandleEventResult::InternalState::HANDLED_INTERNALY};
@@ -137,6 +141,10 @@ public:
         using State = HandleEventResult::InternalState;
         const auto success = allocator.template create_simple<StateType>(std::forward<Args>(args)...);
         return success ? State::NEW_STATE : State::ALLOCATION_ERROR;
+    }
+
+    auto allocator_state() const {
+        return allocator.get_internal_state();
     }
 
     // NOTE (aw): this could also be a non-static function, which checks if any states have been set

--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -62,12 +62,11 @@ inline uint32_t rotate(uint32_t a, uint32_t c) {
 inline uint32_t swap(uint32_t x) {
 #if defined(__GNUC__) || defined(__clang__)
     return __builtin_bswap32(x);
-#endif
-#ifdef _MSC_VER
+#elif defined(_MSC_VER)
     return _byteswap_ulong(x);
-#endif
-
+#else
     return (x >> 24) | ((x >> 8) & 0x0000FF00) | ((x << 8) & 0x00FF0000) | (x << 24);
+#endif
 }
 
 // mix functions for processBlock()


### PR DESCRIPTION
## Summary
- add preflight helper checks in the FSM state allocators
- expose allocator state and use in FSM
- clean up dynamic FSM destruction
- improve Channel::poll error reporting
- fix SHA256 swap portability issue

## Testing
- `./run_tests.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68828b7a1eec8324b8af50645f5e6cfa