### PR TITLE
Fix cross-platform build warnings and example

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,7 +15,9 @@ void setup() {
     // Initialise the SPI bus with custom chip select pin.
     // PLC_SPI_CS_PIN and PLC_SPI_RST_PIN can be overridden via
     // build flags in platformio.ini to match your wiring.
-    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
+    // Use default SPI pins for the selected board. Chip select can be
+    // overridden via PLC_SPI_CS_PIN build flag.
+    SPI.begin();
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
 
     static slac::port::Qca7000Link link(cfg);

--- a/include/slac/endian.hpp
+++ b/include/slac/endian.hpp
@@ -25,8 +25,10 @@
 #endif
 
 #if defined(_WIN32)
+#ifndef __BYTE_ORDER
 #define __BYTE_ORDER __LITTLE_ENDIAN
-#elif defined(__BYTE_ORDER__)
+#endif
+#elif defined(__BYTE_ORDER__) && !defined(__BYTE_ORDER)
 #define __BYTE_ORDER __BYTE_ORDER__
 #elif defined(__BYTE_ORDER)
 /* already defined */

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1,7 +1,16 @@
 #include "qca7000.hpp"
 #include "../port_common.hpp"
 #include "port_config.hpp"
+#ifdef ESP_LOGW
+#pragma push_macro("ESP_LOGW")
+#undef ESP_LOGW
+#define RESTORE_ESP_LOGW
+#endif
 #include "../logging_compat.hpp"
+#ifdef RESTORE_ESP_LOGW
+#pragma pop_macro("ESP_LOGW")
+#undef RESTORE_ESP_LOGW
+#endif
 #include <arpa/inet.h>
 #include <stdint.h>
 #ifndef ESP_PLATFORM

--- a/tests/test_channel.cpp
+++ b/tests/test_channel.cpp
@@ -83,5 +83,6 @@ TEST(Channel, WriteAfterSetupFailure) {
                                    slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_REQ,
                                    slac::defs::MMV::AV_1_0));
     EXPECT_FALSE(msg.is_valid());
+    msg.setup_ethernet_header(dst);
     EXPECT_FALSE(channel.write(msg, 100));
 }


### PR DESCRIPTION
## Summary
- guard `__BYTE_ORDER` definition on Windows
- preserve `ESP_LOGW` macro when including logging compat
- ensure test re-adds Ethernet header before retry
- use default SPI pins in platformio example

## Testing
- `platformio run`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68829903a880832488b1d336a5ab9714