### PR TITLE
Fix missing type_traits includes

### DIFF
--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -7,6 +7,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <type_traits>
 #include <utility>
 
 #include "port/esp32s3/ethernet_defs.hpp"

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstring>
+#include <type_traits>
 
 #include <arpa/inet.h>
 #include <slac/endian.hpp>


### PR DESCRIPTION
## Summary
- add `<type_traits>` in `slac.hpp` and `slac.cpp` for `std::underlying_type_t`
- confirm build with `pio run`

## Testing
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_68829b53ef5883248e9a59d4ee50df5c