### PR TITLE
Fix PlatformIO build

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,12 +21,11 @@ build_flags =
     -fdata-sections              ; remove unused data
     -ffunction-sections          ; remove unused functions
     -fno-exceptions              ; disable exceptions
-    -fno-rtti                    ; disable run-time type info
     -DBUILD_SLAC_TOOLS=OFF       ; omit command line tools
     -DBUILD_TESTING=OFF          ; disable library tests
 
 lib_ldf_mode = chain
-src_filter =
+build_src_filter =
     +<src/channel.cpp>
     +<src/slac.cpp>
     +<port/esp32s3/qca7000.cpp>


### PR DESCRIPTION
## Summary
- fix deprecation warning in `platformio.ini`
- drop C++ `-fno-rtti` flag that produced warnings
- confirm example builds with `pio run`

## Testing
- `pio run`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_68834ea05fe0832497d06ef3803539c3