### PR TITLE
Fix PlatformIO example

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -17,6 +17,7 @@ build_flags =
     -I../..          ; add libslac root to includes
     -I../../include  ; add libslac headers
 
-lib_deps = file://../..
+lib_deps =
+    ../../
     SPI
 lib_ldf_mode = deep


### PR DESCRIPTION
## Summary
- avoid PlatformIO file locking errors by referencing the library via a relative path

## Testing
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_6883554c01a08324b3530f964b1de901