### PR TITLE
Use GitHub libslac in PlatformIO example

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -14,10 +14,8 @@ build_unflags = -std=gnu++11
 build_flags =
     -std=gnu++17     ; use C++17
     -DESP_PLATFORM   ; compile for ESP platform
-    -I../..          ; add libslac root to includes
-    -I../../include  ; add libslac headers
 
 lib_deps =
-    ../../
+    https://github.com/hyndex/libslac.git
     SPI
 lib_ldf_mode = deep


### PR DESCRIPTION
## Summary
- remove local include paths from the PlatformIO example
- pull libslac automatically from GitHub instead of a relative path

## Testing
- `./run_tests.sh`
- `pio run -e esp32s3`

------
https://chatgpt.com/codex/tasks/task_e_68835bf5bd688324a29785e65f429722