### PR TITLE
Fix SPI pin configuration in PlatformIO example

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,9 +15,9 @@ void setup() {
     // Initialise the SPI bus with custom chip select pin.
     // PLC_SPI_CS_PIN and PLC_SPI_RST_PIN can be overridden via
     // build flags in platformio.ini to match your wiring.
-    // Use default SPI pins for the selected board. Chip select can be
-    // overridden via PLC_SPI_CS_PIN build flag.
-    SPI.begin();
+    // Use explicit SPI pins matching the wiring.  Adjust the pin numbers
+    // if your setup differs.
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
 
     static slac::port::Qca7000Link link(cfg);


### PR DESCRIPTION
## Summary
- call `SPI.begin()` with explicit pin numbers in the PlatformIO example

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68836a38e2248324bc7fd9145b900e24