### PR TITLE
Fix SPI pin setup in example

### DIFF
--- a/examples/platformio_complete/README.md
+++ b/examples/platformio_complete/README.md
@@ -15,5 +15,7 @@ pio run -e esp32s3
 
 The project pulls `libslac` automatically via `lib_deps`.
 Custom chip select and reset pins for the modem can be configured by
-editing `build_flags` in `platformio.ini`.
+editing `build_flags` in `platformio.ini`.  Make sure the SPI bus is
+initialised with the correct pin numbers via `SPI.begin()` as shown in
+`src/main.cpp`.
 

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,9 +15,9 @@ void setup() {
     // Initialise the SPI bus with custom chip select pin.
     // PLC_SPI_CS_PIN and PLC_SPI_RST_PIN can be overridden via
     // build flags in platformio.ini to match your wiring.
-    // Use default SPI pins for the selected board. Chip select can be
-    // overridden via PLC_SPI_CS_PIN build flag.
-    SPI.begin();
+    // Use explicit SPI pin assignment to match the wiring.
+    // Adjust the pin numbers or override them via build flags if needed.
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
 
     static slac::port::Qca7000Link link(cfg);


### PR DESCRIPTION
## Summary
- use explicit SPI pin assignment in example `main.cpp`
- mention SPI.begin pin setup in README for example

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68836a3e22c88324ba7847a40ed37a04