### PR TITLE
Fix SPI pin configuration for QCA7000 example

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -14,6 +14,8 @@ build_unflags = -std=gnu++11
 build_flags =
     -std=gnu++17     ; use C++17
     -DESP_PLATFORM   ; compile for ESP platform
+    -DPLC_SPI_CS_PIN=36
+    -DPLC_SPI_RST_PIN=40
 
 lib_deps =
     https://github.com/hyndex/libslac.git

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,9 +15,9 @@ void setup() {
     // Initialise the SPI bus with custom chip select pin.
     // PLC_SPI_CS_PIN and PLC_SPI_RST_PIN can be overridden via
     // build flags in platformio.ini to match your wiring.
-    // Use default SPI pins for the selected board. Chip select can be
-    // overridden via PLC_SPI_CS_PIN build flag.
-    SPI.begin();
+    // Use custom SPI pins matching the modem wiring. Chip select and reset
+    // are provided via build flags in platformio.ini.
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
 
     static slac::port::Qca7000Link link(cfg);


### PR DESCRIPTION
## Summary
- update PlatformIO example to pass board-specific CS and RST pins
- initialise SPI with explicit pin numbers matching the wiring

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68836a3e22c88324ba7847a40ed37a04