### PR TITLE
Fix SPI pin handling for QCA7000 modem

### DIFF
--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -21,10 +21,10 @@ build_flags = \
     -DPLC_SPI_RST_PIN=40
 ```
 
-The SPI bus is started with the custom pins in `setup()`:
+The SPI bus is initialised by the driver using the pin macros from
+`qca7000.hpp`.
 
 ```cpp
-SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, 41 /*CS*/);
 qca7000_config cfg{&SPI, 41, 40, my_mac};
 slac::port::Qca7000Link link(cfg);
 while (true) {

--- a/docs/PlatformIOExample.md
+++ b/docs/PlatformIOExample.md
@@ -79,7 +79,7 @@ static slac::Channel* g_channel = nullptr;
 
 void setup() {
     Serial.begin(115200);
-    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
+    Serial.println("Starting SLAC modem...");
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
     static slac::port::Qca7000Link link(cfg);
     static slac::Channel channel(&link);

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -14,6 +14,8 @@ build_unflags = -std=gnu++11
 build_flags =
     -std=gnu++17     ; use C++17
     -DESP_PLATFORM   ; compile for ESP platform
+    -DPLC_SPI_CS_PIN=36
+    -DPLC_SPI_RST_PIN=40
 
 lib_deps =
     https://github.com/hyndex/libslac.git

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,9 +15,10 @@ void setup() {
     // Initialise the SPI bus with custom chip select pin.
     // PLC_SPI_CS_PIN and PLC_SPI_RST_PIN can be overridden via
     // build flags in platformio.ini to match your wiring.
-    // Use default SPI pins for the selected board. Chip select can be
-    // overridden via PLC_SPI_CS_PIN build flag.
-    SPI.begin();
+    // QCA7000setup() will initialise the SPI bus using the pin macros defined
+    // in port/esp32s3/qca7000.hpp. Override PLC_SPI_*_PIN in platformio.ini if
+    // your wiring differs from the defaults.
+    Serial.println("Starting SLAC modem...");
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
 
     static slac::port::Qca7000Link link(cfg);

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -770,7 +770,7 @@ bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
     g_cs = csPin;
     g_rst = rstPin;
     if (g_spi)
-        g_spi->begin();
+        g_spi->begin(PLC_SPI_SCK_PIN, PLC_SPI_MISO_PIN, PLC_SPI_MOSI_PIN, g_cs);
     pinMode(g_cs, OUTPUT);
     digitalWrite(g_cs, HIGH);
 

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -72,6 +72,15 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
 #ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN 17
 #endif
+#ifndef PLC_SPI_SCK_PIN
+#define PLC_SPI_SCK_PIN 48
+#endif
+#ifndef PLC_SPI_MISO_PIN
+#define PLC_SPI_MISO_PIN 21
+#endif
+#ifndef PLC_SPI_MOSI_PIN
+#define PLC_SPI_MOSI_PIN 47
+#endif
 
 struct qca7000_config {
     SPIClass* spi;


### PR DESCRIPTION
## Summary
- expose pin macros for the SPI bus on ESP32-S3
- start the SPI bus with those pins inside `qca7000setup`
- remove manual `SPI.begin()` from PlatformIO example
- mention automatic pin handling in docs
- print startup message before opening the channel

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68836a3e22c88324ba7847a40ed37a04