### PR TITLE
Fix QCA7000 reset and default RST pin

### DIFF
--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -67,7 +67,11 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
 #endif
 
 #ifndef PLC_SPI_RST_PIN
+#ifdef RST_PIN
+#define PLC_SPI_RST_PIN RST_PIN
+#else
 #define PLC_SPI_RST_PIN 5
+#endif
 #endif
 #ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN 17

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -189,6 +189,7 @@ static bool hardReset() {
         ;
 
     spiWr16_fast(SPI_REG_INTR_CAUSE, 0xFFFF);
+    spiWr16_fast(SPI_REG_INTR_ENABLE, INTR_MASK);
     return true;
 }
 
@@ -778,8 +779,6 @@ bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
         ESP_LOGE(PLC_TAG, "hardReset failed – modem missing");
         return false;
     }
-
-    spiWr16_fast(SPI_REG_INTR_ENABLE, INTR_MASK);
     ESP_LOGI(PLC_TAG, "QCA7000 ready");
     return true;
 }


### PR DESCRIPTION
## Summary
- enable interrupts during hard reset and remove duplicate step
- allow PLC_SPI_RST_PIN to default to RST_PIN when provided
- verify build still works

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_688372b496f08324ba9731973173ff18