### PR TITLE
Update QCA7000 CS handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,9 @@ The SPI pins used to communicate with the QCA7000 modem are defined in
 ``port/esp32s3/qca7000.hpp`` as ``PLC_SPI_CS_PIN`` and ``PLC_SPI_RST_PIN``.
 Override these macros when building to match your hardware wiring or
 specify the pins through ``qca7000_config`` when opening the link.
+Chip select is toggled manually by the driver, therefore ``SPI.begin`` is
+called with ``-1`` as the CS pin and the configured pin is controlled via
+``digitalWrite``.
 
 The ``qca7000_config`` struct allows selecting the SPI bus, chip select
 and reset pins as well as the modem's MAC address when creating

--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -22,7 +22,8 @@ build_flags = \
 ```
 
 The SPI bus is initialised by the driver using the pin macros from
-`qca7000.hpp`.
+`qca7000.hpp`. Chip select is driven manually, so `SPI.begin()` is
+called with `-1` for the CS pin.
 
 ```cpp
 qca7000_config cfg{&SPI, 41, 40, my_mac};

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -771,7 +771,7 @@ bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
     g_cs = csPin;
     g_rst = rstPin;
     if (g_spi)
-        g_spi->begin(PLC_SPI_SCK_PIN, PLC_SPI_MISO_PIN, PLC_SPI_MOSI_PIN, g_cs);
+        g_spi->begin(PLC_SPI_SCK_PIN, PLC_SPI_MISO_PIN, PLC_SPI_MOSI_PIN, -1);
     pinMode(g_cs, OUTPUT);
     digitalWrite(g_cs, HIGH);
 


### PR DESCRIPTION
## Summary
- manually drive CS pin when setting up the modem
- note CS behaviour in README and board example

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688376a14f908324bc78d0281ae308ce