### PR TITLE
Add reset pin check and log

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -127,6 +127,8 @@ The SPI pins used to communicate with the QCA7000 modem are defined in
 ``port/esp32s3/qca7000.hpp`` as ``PLC_SPI_CS_PIN`` and ``PLC_SPI_RST_PIN``.
 Override these macros when building to match your hardware wiring or
 specify the pins through ``qca7000_config`` when opening the link.
+``PLC_SPI_RST_PIN`` must be set for your board; compilation fails if the
+default value is left unchanged.
 
 The ``qca7000_config`` struct allows selecting the SPI bus, chip select
 and reset pins as well as the modem's MAC address when creating

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -771,9 +771,10 @@ bool qca7000setup(SPIClass* bus, int csPin, int rstPin) {
     g_cs = csPin;
     g_rst = rstPin;
     if (g_spi)
-        g_spi->begin(PLC_SPI_SCK_PIN, PLC_SPI_MISO_PIN, PLC_SPI_MOSI_PIN, g_cs);
+        g_spi->begin(PLC_SPI_SCK_PIN, PLC_SPI_MISO_PIN, PLC_SPI_MOSI_PIN, -1);
     pinMode(g_cs, OUTPUT);
     digitalWrite(g_cs, HIGH);
+    ESP_LOGI(PLC_TAG, "Using reset pin %d", g_rst);
 
     if (!hardReset()) {
         ESP_LOGE(PLC_TAG, "hardReset failed – modem missing");

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -69,6 +69,9 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
 #ifndef PLC_SPI_RST_PIN
 #define PLC_SPI_RST_PIN 5
 #endif
+#if PLC_SPI_RST_PIN == 5
+#error "PLC_SPI_RST_PIN must be overridden to match your hardware wiring"
+#endif
 #ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN 17
 #endif

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I."
+CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -DPLC_SPI_RST_PIN=6 -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I."
 SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run


### PR DESCRIPTION
## Summary
- enforce overriding `PLC_SPI_RST_PIN`
- log reset pin selection and use -1 for CS during setup
- document required override in README
- adjust tests to compile with new check

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68837695b84483248c77f49c078ee64b