### PR TITLE
Fix SPI.begin CS pin in example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,9 @@ The QCA7000 driver can be polled instead of relying on an interrupt
 line.  The ``examples/platformio_complete/src/main.cpp`` example calls
 ``qca7000Process()`` from the ``loop()`` function and then polls the
 channel for new packets.  When using this approach the IRQ pin on the
-modem may remain unconnected.
+modem may remain unconnected.  Chip select is controlled manually and the
+example initialises the SPI bus with ``SPI.begin`` using ``-1`` for the CS
+parameter.
 
 .. code-block:: cpp
 

--- a/docs/PlatformIOExample.md
+++ b/docs/PlatformIOExample.md
@@ -80,6 +80,9 @@ static slac::Channel* g_channel = nullptr;
 void setup() {
     Serial.begin(115200);
     Serial.println("Starting SLAC modem...");
+    // Initialise the SPI bus. Chip select is controlled by the driver so
+    // SPI.begin is called with -1 for the CS pin.
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, -1);
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
     static slac::port::Qca7000Link link(cfg);
     static slac::Channel channel(&link);

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -19,11 +19,13 @@ void setup() {
     // in port/esp32s3/qca7000.hpp. Override PLC_SPI_*_PIN in platformio.ini if
     // your wiring differs from the defaults.
     Serial.println("Starting SLAC modem...");
-    // Use custom SPI pins matching the modem wiring. Chip select and reset
-    // are provided via build flags in platformio.ini.
+    // Use custom SPI pins matching the modem wiring. Chip select is handled
+    // manually by the driver, therefore SPI.begin is called with -1 for the CS
+    // parameter. PLC_SPI_CS_PIN and PLC_SPI_RST_PIN are provided via build
+    // flags in platformio.ini.
     Serial.println("Starting SLAC modem...");
-    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, PLC_SPI_CS_PIN);
-    Serial.println("Starting SPI ");
+    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, -1);
+    Serial.println("Starting SPI");
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
     Serial.println("Starting QCA7000 Link ");
     static slac::port::Qca7000Link link(cfg);


### PR DESCRIPTION
## Summary
- use CS=-1 in platformio example
- document manual CS handling in README and tutorial

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688379854b348324a2086dae262b30cb