### PR TITLE
Add duplicate code warnings

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -21,6 +21,8 @@ build_flags =
     -fdata-sections              ; remove unused data
     -ffunction-sections          ; remove unused functions
     -fno-exceptions              ; disable exceptions
+    -Wduplicated-cond            ; warn on duplicated conditions
+    -Wduplicated-branches        ; warn on duplicated branches
     -DBUILD_SLAC_TOOLS=OFF       ; omit command line tools
     -DBUILD_TESTING=OFF          ; disable library tests
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
-CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I."
+CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
 SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run


### PR DESCRIPTION
## Summary
- enable `-Wduplicated-cond` and `-Wduplicated-branches` warnings during test and firmware builds

## Testing
- `./run_tests.sh`
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_68837b04cdd883249bfd2e979fc51398