### PR TITLE
Add soft reset fallback handling

### DIFF
--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -94,6 +94,10 @@ size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
 uint8_t qca7000getSlacResult();
+// Poll the modem for events and service the RX ring.
+// When a CPU_ON or buffer error interrupt occurs the driver first
+// performs qca7000SoftReset(). If that fails the reset pin is toggled
+// via a hard reset.
 void qca7000Process();
 
 typedef void (*qca7000_error_cb_t)(void*);

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -733,19 +733,20 @@ void qca7000Process() {
 
         if (cause & SPI_INT_CPU_ON) {
             clear_mask |= SPI_INT_CPU_ON;
-            hardReset();
+            if (!qca7000SoftReset())
+                hardReset();
             if (g_err_cb.flag)
                 *g_err_cb.flag = true;
             if (g_err_cb.cb)
                 g_err_cb.cb(g_err_cb.arg);
-            qca7000setup(g_spi, g_cs, g_rst);
             spiWr16_fast(SPI_REG_INTR_CAUSE, clear_mask);
             spiWr16_fast(SPI_REG_INTR_ENABLE, INTR_MASK);
             return;
         }
         if (cause & (SPI_INT_WRBUF_ERR | SPI_INT_RDBUF_ERR)) {
             clear_mask |= SPI_INT_WRBUF_ERR | SPI_INT_RDBUF_ERR;
-            hardReset();
+            if (!qca7000SoftReset())
+                hardReset();
             if (g_err_cb.flag)
                 *g_err_cb.flag = true;
             if (g_err_cb.cb)

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -99,6 +99,10 @@ size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
 uint8_t qca7000getSlacResult();
+// Poll the modem for events and service the RX ring.
+// If a CPU_ON or buffer error interrupt is detected the driver
+// attempts a soft reset via qca7000SoftReset(). Should that fail the
+// reset pin is toggled using a hard reset.
 void qca7000Process();
 
 typedef void (*qca7000_error_cb_t)(void*);


### PR DESCRIPTION
## Summary
- reset the QCA7000 using `qca7000SoftReset()` first in `qca7000Process`
- fall back to toggling the reset pin when the soft reset fails
- document new behaviour in the public headers

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68837b0978ec8324918a84c2d241beb0