### PR TITLE
Add test for qca7000 reset

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/tests/test_reset.cpp
+++ b/tests/test_reset.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+#define ARDUINO
+#include "arduino_stubs.hpp"
+#include "port/esp32s3/qca7000.hpp"
+
+TEST(Qca7000ResetSimple, ReturnsTrue) {
+    ASSERT_TRUE(qca7000ResetAndCheck());
+}


### PR DESCRIPTION
## Summary
- add a simple test calling `qca7000ResetAndCheck`
- compile the new test in `run_tests.sh`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68837f4ebd548324ae0e7b16ce04e502