### PR TITLE
Configure default pins and clean up driver

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -29,6 +29,9 @@ void setup() {
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
     Serial.println("Starting QCA7000 Link ");
     static slac::port::Qca7000Link link(cfg);
+    link.set_error_callback([](void*) {
+        Serial.println("[PLC] Fatal error - driver auto-reset");
+    }, nullptr);
     static slac::Channel channel(&link);
     g_channel = &channel;
     if (!channel.open()) {

--- a/include/port/esp32s3/port_config.hpp
+++ b/include/port/esp32s3/port_config.hpp
@@ -3,29 +3,44 @@
 
 #include "../port_common.hpp"
 
+#define PLC_SPI_CS_PIN   36
+#define PLC_SPI_RST_PIN  40
+#define PLC_SPI_SCK_PIN  48
+#define PLC_SPI_MISO_PIN 21
+#define PLC_SPI_MOSI_PIN 47
+
 #ifdef ESP_PLATFORM
 #include <stdint.h>
-
-namespace slac {
-inline uint16_t le16toh(uint16_t v) {
-    return v;
-}
-inline uint16_t htole16(uint16_t v) {
-    return v;
-}
-inline uint32_t le32toh(uint32_t v) {
-    return v;
-}
-inline uint32_t htole32(uint32_t v) {
-    return v;
-}
-} // namespace slac
-
 #include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
 #include <freertos/task.h>
+#endif
 
+#define PLC_SPI_SLOW_HZ  1000000
+#define QCA7000_SPI_FAST_HZ 8000000
+#define QCA7000_SPI_BURST_LEN 512
+
+static_assert(PLC_SPI_CS_PIN >= 0, "CS pin unset");
+static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
+static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
+
+namespace slac {
+#ifndef le16toh
+inline uint16_t le16toh(uint16_t v) { return v; }
+#endif
+#ifndef htole16
+inline uint16_t htole16(uint16_t v) { return v; }
+#endif
+#ifndef le32toh
+inline uint32_t le32toh(uint32_t v) { return v; }
+#endif
+#ifndef htole32
+inline uint32_t htole32(uint32_t v) { return v; }
+#endif
+} // namespace slac
+
+#ifdef ESP_PLATFORM
 static inline uint32_t slac_millis() {
     return (uint32_t)(esp_timer_get_time() / 1000ULL);
 }

--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "../port_common.hpp"
-#ifdef ESP_PLATFORM
 #include "port_config.hpp"
-#endif
 
 #include "ethernet_defs.hpp"
 #ifdef ARDUINO
@@ -59,26 +57,6 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
 #define QCASPI_SLAVE_RESET_BIT (1 << 6)
 #endif
 
-#ifndef QCA7000_SPI_FAST_HZ
-#define QCA7000_SPI_FAST_HZ 8000000
-#endif
-#ifndef PLC_SPI_SLOW_HZ
-#define PLC_SPI_SLOW_HZ 1000000
-#endif
-#ifndef QCA7000_SPI_BURST_LEN
-#define QCA7000_SPI_BURST_LEN 512
-#endif
-
-#ifndef PLC_SPI_RST_PIN
-#ifdef RST_PIN
-#define PLC_SPI_RST_PIN RST_PIN
-#else
-#define PLC_SPI_RST_PIN 5
-#endif
-#endif
-#ifndef PLC_SPI_CS_PIN
-#define PLC_SPI_CS_PIN 17
-#endif
 
 struct qca7000_config {
     SPIClass* spi;

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,6 +1,14 @@
 [platformio]
 src_dir = .
 
+[env]
+build_flags =
+  -DPLC_SPI_CS_PIN=36
+  -DPLC_SPI_RST_PIN=40
+  -DPLC_SPI_SCK_PIN=48
+  -DPLC_SPI_MOSI_PIN=47
+  -DPLC_SPI_MISO_PIN=21
+
 [env:esp32s3]
 platform = espressif32 ; use ESP32 toolchain version 6.5.0
 board = esp32-s3-devkitc-1  ; target board

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -3,29 +3,45 @@
 
 #include "../port_common.hpp"
 
+
+#define PLC_SPI_CS_PIN   36
+#define PLC_SPI_RST_PIN  40
+#define PLC_SPI_SCK_PIN  48
+#define PLC_SPI_MISO_PIN 21
+#define PLC_SPI_MOSI_PIN 47
+
 #ifdef ESP_PLATFORM
 #include <stdint.h>
-
-namespace slac {
-inline uint16_t le16toh(uint16_t v) {
-    return v;
-}
-inline uint16_t htole16(uint16_t v) {
-    return v;
-}
-inline uint32_t le32toh(uint32_t v) {
-    return v;
-}
-inline uint32_t htole32(uint32_t v) {
-    return v;
-}
-} // namespace slac
-
 #include <esp_timer.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
 #include <freertos/task.h>
+#endif
 
+#define PLC_SPI_SLOW_HZ  1000000
+#define QCA7000_SPI_FAST_HZ 8000000
+#define QCA7000_SPI_BURST_LEN 512
+
+static_assert(PLC_SPI_CS_PIN >= 0, "CS pin unset");
+static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
+static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
+
+namespace slac {
+#ifndef le16toh
+inline uint16_t le16toh(uint16_t v) { return v; }
+#endif
+#ifndef htole16
+inline uint16_t htole16(uint16_t v) { return v; }
+#endif
+#ifndef le32toh
+inline uint32_t le32toh(uint32_t v) { return v; }
+#endif
+#ifndef htole32
+inline uint32_t htole32(uint32_t v) { return v; }
+#endif
+} // namespace slac
+
+#ifdef ESP_PLATFORM
 static inline uint32_t slac_millis() {
     return (uint32_t)(esp_timer_get_time() / 1000ULL);
 }

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "../port_common.hpp"
-#ifdef ESP_PLATFORM
 #include "port_config.hpp"
-#endif
 
 #include "ethernet_defs.hpp"
 #ifdef ARDUINO
@@ -59,31 +57,6 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
 #define QCASPI_SLAVE_RESET_BIT (1 << 6)
 #endif
 
-#ifndef QCA7000_SPI_FAST_HZ
-#define QCA7000_SPI_FAST_HZ 8000000
-#endif
-#ifndef PLC_SPI_SLOW_HZ
-#define PLC_SPI_SLOW_HZ 1000000
-#endif
-#ifndef QCA7000_SPI_BURST_LEN
-#define QCA7000_SPI_BURST_LEN 512
-#endif
-
-#ifndef PLC_SPI_RST_PIN
-#define PLC_SPI_RST_PIN 5
-#endif
-#ifndef PLC_SPI_CS_PIN
-#define PLC_SPI_CS_PIN 17
-#endif
-#ifndef PLC_SPI_SCK_PIN
-#define PLC_SPI_SCK_PIN 48
-#endif
-#ifndef PLC_SPI_MISO_PIN
-#define PLC_SPI_MISO_PIN 21
-#endif
-#ifndef PLC_SPI_MOSI_PIN
-#define PLC_SPI_MOSI_PIN 47
-#endif
 
 struct qca7000_config {
     SPIClass* spi;


### PR DESCRIPTION
## Summary
- centralize SPI pin definitions in `port_config.hpp`
- remove duplicate pin macros from driver headers
- expose error callback in example
- set default pin macros in PlatformIO config

## Testing
- `./run_tests.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_688382360b448324a6739a8300f3dd46