### PR TITLE
Add static asserts for SPI pin definitions

### DIFF
--- a/include/port/esp32s3/port_config.hpp
+++ b/include/port/esp32s3/port_config.hpp
@@ -21,8 +21,16 @@
 #define QCA7000_SPI_FAST_HZ 8000000
 #define QCA7000_SPI_BURST_LEN 512
 
+#ifndef PLC_SPI_CS_PIN
+static_assert(false, "PLC_SPI_CS_PIN undefined");
+#else
 static_assert(PLC_SPI_CS_PIN >= 0, "CS pin unset");
+#endif
+#ifndef PLC_SPI_RST_PIN
+static_assert(false, "PLC_SPI_RST_PIN undefined");
+#else
 static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
+#endif
 static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
 
 namespace slac {

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -22,8 +22,16 @@
 #define QCA7000_SPI_FAST_HZ 8000000
 #define QCA7000_SPI_BURST_LEN 512
 
+#ifndef PLC_SPI_CS_PIN
+static_assert(false, "PLC_SPI_CS_PIN undefined");
+#else
 static_assert(PLC_SPI_CS_PIN >= 0, "CS pin unset");
+#endif
+#ifndef PLC_SPI_RST_PIN
+static_assert(false, "PLC_SPI_RST_PIN undefined");
+#else
 static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
+#endif
 static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
 
 namespace slac {

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -41,6 +41,7 @@ static constexpr uint16_t TX_HDR = 8;
 static constexpr uint16_t RX_HDR = 12;
 static constexpr uint16_t FTR_LEN = 2;
 static constexpr size_t BURST_LEN = QCA7000_SPI_BURST_LEN;
+static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
 static constexpr uint16_t INTR_MASK = SPI_INT_CPU_ON | SPI_INT_PKT_AVLBL | SPI_INT_RDBUF_ERR | SPI_INT_WRBUF_ERR;
 
 using FSMBuffer = slac::fsm::buffer::SwapBuffer<64, 0, 1>;


### PR DESCRIPTION
## Summary
- ensure that PLC SPI pin macros are defined and valid
- add compile-time guard for SPI burst size

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68838f3ba1388324bb3731a226fa98af