### PR TITLE
Configure PLC pins for ESP32‑S3

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,13 +1,6 @@
 [platformio]
 src_dir = .
 
-[env]
-build_flags =
-  -DPLC_SPI_CS_PIN=36
-  -DPLC_SPI_RST_PIN=40
-  -DPLC_SPI_SCK_PIN=48
-  -DPLC_SPI_MOSI_PIN=47
-  -DPLC_SPI_MISO_PIN=21
 
 [env:esp32s3]
 platform = espressif32 ; use ESP32 toolchain version 6.5.0
@@ -33,6 +26,12 @@ build_flags =
     -Wduplicated-branches        ; warn on duplicated branches
     -DBUILD_SLAC_TOOLS=OFF       ; omit command line tools
     -DBUILD_TESTING=OFF          ; disable library tests
+    -DPLC_SPI_CS_PIN=36
+    -DPLC_SPI_RST_PIN=40
+    -DPLC_SPI_SCK_PIN=48
+    -DPLC_SPI_MOSI_PIN=47
+    -DPLC_SPI_MISO_PIN=21
+    -Wl,-Map,firmware.map        ; optional linker map
 
 lib_ldf_mode = chain
 build_src_filter =


### PR DESCRIPTION
## Summary
- move PLC pin macros into the `esp32s3` build environment
- generate optional linker map when building firmware

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68838f40cae083249bba56c996b2243d