### PR TITLE
Add configurable reset timings

### DIFF
--- a/include/port/esp32s3/port_config.hpp
+++ b/include/port/esp32s3/port_config.hpp
@@ -3,11 +3,21 @@
 
 #include "../port_common.hpp"
 
+#ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN   36
+#endif
+#ifndef PLC_SPI_RST_PIN
 #define PLC_SPI_RST_PIN  40
+#endif
+#ifndef PLC_SPI_SCK_PIN
 #define PLC_SPI_SCK_PIN  48
+#endif
+#ifndef PLC_SPI_MISO_PIN
 #define PLC_SPI_MISO_PIN 21
+#endif
+#ifndef PLC_SPI_MOSI_PIN
 #define PLC_SPI_MOSI_PIN 47
+#endif
 
 #ifdef ESP_PLATFORM
 #include <stdint.h>
@@ -20,6 +30,16 @@
 #define PLC_SPI_SLOW_HZ  1000000
 #define QCA7000_SPI_FAST_HZ 8000000
 #define QCA7000_SPI_BURST_LEN 512
+
+#ifndef QCA7000_HARDRESET_LOW_MS
+#define QCA7000_HARDRESET_LOW_MS 20
+#endif
+#ifndef QCA7000_HARDRESET_HIGH_MS
+#define QCA7000_HARDRESET_HIGH_MS 150
+#endif
+#ifndef QCA7000_CPUON_TIMEOUT_MS
+#define QCA7000_CPUON_TIMEOUT_MS 200
+#endif
 
 #ifndef PLC_SPI_CS_PIN
 static_assert(false, "PLC_SPI_CS_PIN undefined");

--- a/platformio.ini
+++ b/platformio.ini
@@ -31,6 +31,9 @@ build_flags =
     -DPLC_SPI_SCK_PIN=48
     -DPLC_SPI_MOSI_PIN=47
     -DPLC_SPI_MISO_PIN=21
+    -DQCA7000_HARDRESET_LOW_MS=20
+    -DQCA7000_HARDRESET_HIGH_MS=150
+    -DQCA7000_CPUON_TIMEOUT_MS=200
     -Wl,-Map,firmware.map        ; optional linker map
 
 lib_ldf_mode = chain

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -4,11 +4,21 @@
 #include "../port_common.hpp"
 
 
+#ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN   36
+#endif
+#ifndef PLC_SPI_RST_PIN
 #define PLC_SPI_RST_PIN  40
+#endif
+#ifndef PLC_SPI_SCK_PIN
 #define PLC_SPI_SCK_PIN  48
+#endif
+#ifndef PLC_SPI_MISO_PIN
 #define PLC_SPI_MISO_PIN 21
+#endif
+#ifndef PLC_SPI_MOSI_PIN
 #define PLC_SPI_MOSI_PIN 47
+#endif
 
 #ifdef ESP_PLATFORM
 #include <stdint.h>
@@ -21,6 +31,16 @@
 #define PLC_SPI_SLOW_HZ  1000000
 #define QCA7000_SPI_FAST_HZ 8000000
 #define QCA7000_SPI_BURST_LEN 512
+
+#ifndef QCA7000_HARDRESET_LOW_MS
+#define QCA7000_HARDRESET_LOW_MS 20
+#endif
+#ifndef QCA7000_HARDRESET_HIGH_MS
+#define QCA7000_HARDRESET_HIGH_MS 150
+#endif
+#ifndef QCA7000_CPUON_TIMEOUT_MS
+#define QCA7000_CPUON_TIMEOUT_MS 200
+#endif
 
 #ifndef PLC_SPI_CS_PIN
 static_assert(false, "PLC_SPI_CS_PIN undefined");

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -172,9 +172,9 @@ static void spiWr16_slow(uint16_t reg, uint16_t val) {
 static bool hardReset() {
     pinMode(g_rst, OUTPUT);
     digitalWrite(g_rst, LOW);
-    slac_delay(10);
+    slac_delay(QCA7000_HARDRESET_LOW_MS);
     digitalWrite(g_rst, HIGH);
-    slac_delay(100);
+    slac_delay(QCA7000_HARDRESET_HIGH_MS);
 
     auto slowRd16 = [&](uint16_t reg) -> uint16_t {
         g_spi->beginTransaction(setSlow);
@@ -205,7 +205,8 @@ static bool hardReset() {
     ESP_LOGI(PLC_TAG, "Reset probe OK (SIG=0x%04X)", sig);
 
     t0 = slac_millis();
-    while (!(slowRd16(SPI_REG_INTR_CAUSE) & SPI_INT_CPU_ON) && slac_millis() - t0 < 80)
+    while (!(slowRd16(SPI_REG_INTR_CAUSE) & SPI_INT_CPU_ON) &&
+           slac_millis() - t0 < QCA7000_CPUON_TIMEOUT_MS)
         ;
 
     spiWr16_slow(SPI_REG_INTR_CAUSE, 0xFFFF);


### PR DESCRIPTION
## Summary
- make SPI pin defines overridable
- add configurable reset timing defines to `port_config.hpp`
- use new macros for reset delays in `qca7000.cpp`
- expose the macros via `platformio.ini`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883acbe61e08324a68ff4afaecf4fe5