### PR TITLE
Add retry and power control in modem setup

### DIFF
--- a/include/port/esp32s3/port_config.hpp
+++ b/include/port/esp32s3/port_config.hpp
@@ -41,6 +41,14 @@
 #define QCA7000_CPUON_TIMEOUT_MS 200
 #endif
 
+#ifndef QCA7000_MAX_RETRIES
+#define QCA7000_MAX_RETRIES 3
+#endif
+
+#ifndef PLC_PWR_EN_PIN
+#define PLC_PWR_EN_PIN -1
+#endif
+
 #ifndef PLC_SPI_CS_PIN
 static_assert(false, "PLC_SPI_CS_PIN undefined");
 #else


### PR DESCRIPTION
## Summary
- make retry count configurable
- allow optional modem power pin
- retry setup multiple times with power cycle

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883b2e3708c8324a35cfa4b6ff09300