### PR TITLE
Add QCA7000 health check helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,7 +118,8 @@ calls will not attempt to reinitialise the modem.  Call
 Unexpected modem resets are reported through an optional callback or
 error flag. Use ``link.set_error_callback(cb, arg)`` to register a
 callback and periodically check ``link.fatal_error()`` when polling the
-driver.
+driver. Call ``qca7000CheckAlive()`` roughly once per minute to
+confirm that the modem is still responsive.
 
 QCA7000 Configuration
 ---------------------

--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -78,6 +78,11 @@ bool qca7000ResetAndCheck();
 bool qca7000SoftReset();
 uint16_t qca7000ReadInternalReg(uint16_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);
+// Poll a few internal registers to verify that the modem is responsive.
+// Returns ``true`` when ``SPI_REG_SIGNATURE`` matches 0xAA55 and the
+// ``CPU_ON`` interrupt cause is asserted.  Applications should invoke this
+// check roughly once per minute to detect a stalled device.
+bool qca7000CheckAlive();
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -281,6 +281,13 @@ bool qca7000ReadSignature(uint16_t* s, uint16_t* v) {
     return sig == SIG;
 }
 
+bool qca7000CheckAlive() {
+    uint16_t sig = qca7000ReadInternalReg(SPI_REG_SIGNATURE);
+    (void)qca7000ReadInternalReg(SPI_REG_WRBUF_SPC_AVA);
+    uint16_t cause = qca7000ReadInternalReg(SPI_REG_INTR_CAUSE);
+    return sig == SIG && (cause & SPI_INT_CPU_ON);
+}
+
 #ifdef LIBSLAC_TESTING
 bool txFrame(const uint8_t* eth, size_t ethLen) {
 #else

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -78,6 +78,11 @@ bool qca7000ResetAndCheck();
 bool qca7000SoftReset();
 uint16_t qca7000ReadInternalReg(uint16_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);
+// Poll a few internal registers to verify that the modem is responsive.
+// Returns ``true`` when ``SPI_REG_SIGNATURE`` matches 0xAA55 and the
+// ``CPU_ON`` interrupt cause is asserted.  Applications should invoke this
+// check roughly once per minute to detect a stalled device.
+bool qca7000CheckAlive();
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -2,7 +2,7 @@
 set -e
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/tests/test_check_alive.cpp
+++ b/tests/test_check_alive.cpp
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#define ARDUINO
+#include "arduino_stubs.hpp"
+#include "port/esp32s3/qca7000.hpp"
+
+extern uint16_t mock_signature;
+extern uint16_t mock_wrbuf;
+extern uint16_t mock_intr_cause;
+
+TEST(Qca7000CheckAlive, ReturnsTrue) {
+    mock_signature = 0xAA55;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = SPI_INT_CPU_ON;
+    EXPECT_TRUE(qca7000CheckAlive());
+}
+
+TEST(Qca7000CheckAlive, WrongSignature) {
+    mock_signature = 0x1234;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = SPI_INT_CPU_ON;
+    EXPECT_FALSE(qca7000CheckAlive());
+}
+
+TEST(Qca7000CheckAlive, CpuOff) {
+    mock_signature = 0xAA55;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = 0;
+    EXPECT_FALSE(qca7000CheckAlive());
+}


### PR DESCRIPTION
## Summary
- add `qca7000CheckAlive()` helper in the driver
- expose it via headers
- document periodic health check
- provide unit tests and mocks for `qca7000CheckAlive`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883b5e174488324a71fa240f5ec0b05