### PR TITLE
Fix missing macros and update platformio example

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -20,7 +20,7 @@ void setup() {
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, MY_MAC};
     Serial.println("Starting QCA7000 Link ");
     static slac::port::Qca7000Link link(cfg);
-    link.set_error_callback([](void*) {
+    link.set_error_callback([](Qca7000ErrorStatus, void*) {
         Serial.println("[PLC] Fatal error - driver auto-reset");
     }, nullptr);
     static slac::Channel channel(&link);

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,6 +40,7 @@ lib_ldf_mode = chain
 build_src_filter =
     +<src/channel.cpp>
     +<src/slac.cpp>
+    +<src/config.cpp>
     +<port/esp32s3/qca7000.cpp>
     +<port/esp32s3/qca7000_link.cpp>
     +<3rd_party/hash_library/sha256.cpp>

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -42,6 +42,14 @@
 #define QCA7000_CPUON_TIMEOUT_MS 200
 #endif
 
+#ifndef QCA7000_MAX_RETRIES
+#define QCA7000_MAX_RETRIES 3
+#endif
+
+#ifndef PLC_PWR_EN_PIN
+#define PLC_PWR_EN_PIN -1
+#endif
+
 #ifndef PLC_SPI_CS_PIN
 static_assert(false, "PLC_SPI_CS_PIN undefined");
 #else


### PR DESCRIPTION
## Summary
- define PLC_PWR_EN_PIN and QCA7000_MAX_RETRIES in esp32s3 port config
- fix example callback signature and include config source in PlatformIO build

## Testing
- `./run_tests.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6883bc0d457883248e05c6031301ef24