### PR TITLE
Fix default argument in example

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -4,7 +4,10 @@
 #include <port/esp32s3/qca7000_link.hpp>
 #include <port/esp32s3/qca7000.hpp>
 
-extern void qca7000ProcessSlice(uint32_t max_us = 500);
+// qca7000ProcessSlice is declared in qca7000.hpp with a default timeout.
+// The extern declaration here must not specify the default again to avoid
+// multiple default argument definitions.
+extern void qca7000ProcessSlice(uint32_t max_us);
 
 // Default MAC address for the modem. Adjust as required.
 static const uint8_t MY_MAC[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};


### PR DESCRIPTION
## Summary
- avoid repeating default argument when declaring `qca7000ProcessSlice`

## Testing
- `./run_tests.sh` *(fails: gtest missing)*
- `platformio run -d examples/platformio_complete`

------
https://chatgpt.com/codex/tasks/task_e_6883ca53152c8324991fcae5759dc614