### PR TITLE
Add gtest note

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,6 +244,26 @@ state machines.  Include ``<slac/fsm.hpp>`` and derive your states from
 ``slac::fsm::states::CompoundStateBase``.  The helper classes manage
 state transitions and optionally operate without heap allocations.
 
+Running Unit Tests
+------------------
+
+The ``run_tests.sh`` script builds and executes the unit tests.  It
+links against the system provided GoogleTest libraries and therefore
+requires the ``libgtest-dev`` package (or an equivalent package provided
+by your distribution).  On Debian/Ubuntu based systems install the
+dependency via ``apt`` before running the script:
+
+.. code-block:: bash
+
+   sudo apt-get install libgtest-dev
+
+Execute the tests with:
+
+.. code-block:: bash
+
+   ./run_tests.sh
+
+
 Vendored Dependencies
 ---------------------
 

--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -26,6 +26,7 @@ inline SPIClass SPI;
 inline void pinMode(int, int) {}
 inline void digitalWrite(int, int) {}
 inline uint32_t millis() { return 0; }
+inline uint32_t micros() { return 0; }
 inline void delay(unsigned int) {}
 inline void noInterrupts() {}
 inline void interrupts() {}


### PR DESCRIPTION
## Summary
- document that `run_tests.sh` relies on system-provided GoogleTest
- stub Arduino `micros()` so tests build on host

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883ca6ce45c8324871afc47ef50ee12