### PR TITLE
Update docs for PLC_INT_PIN usage

### DIFF
--- a/docs/qca7000-bring-up.md
+++ b/docs/qca7000-bring-up.md
@@ -14,7 +14,19 @@ The ESP32-S3 port defines default SPI pins in `port/esp32s3/qca7000.hpp`:
 | Chip Select   | `PLC_SPI_CS_PIN`    | 17          |
 | Reset         | `PLC_SPI_RST_PIN`   | 5           |
 
-Override these macros or pass explicit values to `qca7000_config` if your wiring differs. The optional interrupt line is unused by the provided driver and may remain unconnected.
+Override these macros or pass explicit values to `qca7000_config` if your wiring differs. The interrupt line is defined by `PLC_INT_PIN` (IO16 in the example configuration) and should be connected so an ISR can call `qca7000ProcessSlice()` when the modem signals new data.
+
+```cpp
+volatile bool plc_irq = false;
+void IRAM_ATTR plc_isr() { plc_irq = true; }
+
+void loop() {
+    if (plc_irq) {
+        plc_irq = false;
+        qca7000ProcessSlice();
+    }
+}
+```
 
 ## Typical Serial Log
 

--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -26,6 +26,7 @@ inline SPIClass SPI;
 inline void pinMode(int, int) {}
 inline void digitalWrite(int, int) {}
 inline uint32_t millis() { return 0; }
+inline uint32_t micros() { return 0; }
 inline void delay(unsigned int) {}
 inline void noInterrupts() {}
 inline void interrupts() {}


### PR DESCRIPTION
## Summary
- mention the interrupt pin as recommended in `BoardExample.md`
- update the board example code snippet with ISR-based `qca7000ProcessSlice()`
- recommend connecting `PLC_INT_PIN` in the bring-up guide and show ISR loop
- add `micros()` stub for the unit tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883ca6440dc8324a1adb113b13455d4