### PR TITLE
Update docs for IRQ usage and fix tests

### DIFF
--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -2,7 +2,8 @@
 
 This example demonstrates how to wire the QCA7000 modem to an
 ESP32-S3 board using PlatformIO. The board uses custom SPI pins and
-operates the modem without connecting the optional interrupt line.
+connects the modem's INT\_N line to ``IO16`` so the driver can react to
+interrupts quickly.
 
 ## PlatformIO configuration
 
@@ -19,7 +20,8 @@ board_build.arduino.memory_type = dio_qspi
 build_flags = \
     -DPLC_SPI_CS_PIN=41 \
     -DPLC_SPI_RST_PIN=40 \
-    -DPLC_SPI_SLOW_HZ=500000
+    -DPLC_SPI_SLOW_HZ=500000 \
+    -DPLC_INT_PIN=16
 ```
 
 The SPI bus is initialised by the driver using the pin macros from
@@ -29,11 +31,22 @@ called with `-1` for the CS pin.
 ```cpp
 qca7000_config cfg{&SPI, 41, 40, my_mac};
 slac::port::Qca7000Link link(cfg);
+volatile bool plc_irq = false;
+
+void IRAM_ATTR plc_isr() { plc_irq = true; }
+
+pinMode(PLC_INT_PIN, INPUT);
+attachInterrupt(PLC_INT_PIN, plc_isr, FALLING);
+
 while (true) {
-    qca7000Process();
+    if (plc_irq) {
+        plc_irq = false;
+        qca7000ProcessSlice();
+    }
     // application tasks
 }
 ```
 
-No interrupt pin is used. The loop above shows how the modem can be
-polled without relying on an external IRQ line.
+With ``PLC_INT_PIN`` connected the driver wakes only when the QCA7000
+signals an interrupt. ``qca7000ProcessSlice()`` limits the processing
+time so other application tasks keep running smoothly.

--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -26,6 +26,7 @@ inline SPIClass SPI;
 inline void pinMode(int, int) {}
 inline void digitalWrite(int, int) {}
 inline uint32_t millis() { return 0; }
+inline uint32_t micros() { return 0; }
 inline void delay(unsigned int) {}
 inline void noInterrupts() {}
 inline void interrupts() {}


### PR DESCRIPTION
## Summary
- document INT pin use and new `qca7000ProcessSlice()` pattern
- add missing `micros()` stub so unit tests build

## Testing
- `./run_tests.sh`
- `pio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_6883c8da828c8324a87e62492c7833fb