### PR TITLE
Improve QCA7000 interrupt handling

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -55,7 +55,7 @@ void loop() {
     Serial.println("Loop Started");
     if (plc_irq) {
         plc_irq = false;
-        qca7000ProcessSlice();
+        qca7000ProcessSlice(500);
     }
     Serial.println("Loop Middle");
 

--- a/port/esp32s3/qca7000_uart.cpp
+++ b/port/esp32s3/qca7000_uart.cpp
@@ -22,7 +22,7 @@ struct RxEntry {
     size_t len;
     uint8_t data[V2GTP_BUFFER_SIZE];
 };
-static constexpr uint8_t RING_SIZE = 4;
+static constexpr uint8_t RING_SIZE = 8;
 static constexpr uint8_t RING_MASK = RING_SIZE - 1;
 static RxEntry ring[RING_SIZE];
 static std::atomic<uint8_t> head{0}, tail{0};


### PR DESCRIPTION
## Summary
- keep a deeper RX ring for SPI and UART drivers
- handle CPU_ON by reinitialising instead of resetting
- clear all interrupt causes when servicing IRQs
- power-cycle after repeated buffer errors
- fix example build with explicit timeout

## Testing
- `./run_tests.sh`
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_6883cbbb4ab0832495a2b1c48aa2a9dc