### PR TITLE
Enhance example stability and logging

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -1,9 +1,10 @@
 #include "cp_monitor.h"
+#include <atomic>
 
 static hw_timer_t* adcTimer = nullptr;
-static volatile uint16_t cp_mv = 0;
-static volatile uint16_t cp_duty = 0;
-static volatile CpSubState cp_state = CP_A;
+static std::atomic<uint16_t> cp_mv{0};
+static std::atomic<uint16_t> cp_duty{0};
+static std::atomic<CpSubState> cp_state{CP_A};
 
 static char toLetter(CpSubState s) {
     switch (s) {
@@ -38,15 +39,16 @@ static void IRAM_ATTR onAdc() {
         if (v > vmax)
             vmax = v;
     }
-    cp_mv = vmax;
-    cp_state = mv2state(vmax);
+    cp_mv.store(vmax, std::memory_order_relaxed);
+    cp_state.store(mv2state(vmax), std::memory_order_relaxed);
 }
 
 void cpMonitorInit() {
     analogReadResolution(12);
     analogSetPinAttenuation(CP_READ_ADC_PIN, ADC_11db);
-    cp_mv = analogReadMilliVolts(CP_READ_ADC_PIN);
-    cp_state = mv2state(cp_mv);
+    uint16_t mv = analogReadMilliVolts(CP_READ_ADC_PIN);
+    cp_mv.store(mv, std::memory_order_relaxed);
+    cp_state.store(mv2state(mv), std::memory_order_relaxed);
 }
 
 void cpLowRateStart(uint32_t period_ms) {
@@ -62,10 +64,13 @@ void cpLowRateStop() {
         timerAlarmDisable(adcTimer);
 }
 
-float cpGetVoltageMv() { return static_cast<float>(cp_mv); }
-CpSubState cpGetSubState() { return cp_state; }
-char cpGetStateLetter() { return toLetter(cp_state); }
+float cpGetVoltageMv() { return static_cast<float>(cp_mv.load(std::memory_order_relaxed)); }
+CpSubState cpGetSubState() { return cp_state.load(std::memory_order_relaxed); }
+char cpGetStateLetter() { return toLetter(cp_state.load(std::memory_order_relaxed)); }
 
-void cpSetLastPwmDuty(uint16_t duty) { cp_duty = duty; }
-uint16_t cpGetLastPwmDuty() { return cp_duty; }
-bool cpDigitalCommRequested() { return cp_state == CP_B1 || cp_state == CP_B2; }
+void cpSetLastPwmDuty(uint16_t duty) { cp_duty.store(duty, std::memory_order_relaxed); }
+uint16_t cpGetLastPwmDuty() { return cp_duty.load(std::memory_order_relaxed); }
+bool cpDigitalCommRequested() {
+    CpSubState s = cp_state.load(std::memory_order_relaxed);
+    return s == CP_B1 || s == CP_B2;
+}

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -1,7 +1,8 @@
 #include "cp_pwm.h"
 #include "cp_monitor.h"
+#include <atomic>
 
-static bool pwmRunning = false;
+static std::atomic<bool> pwmRunning{false};
 static constexpr uint8_t PWM_CHANNEL = 0;
 
 void cpPwmInit() {
@@ -13,11 +14,11 @@ void cpPwmInit() {
 void cpPwmStart(uint16_t duty_raw) {
     ledcWrite(PWM_CHANNEL, duty_raw);
     cpSetLastPwmDuty(duty_raw);
-    pwmRunning = true;
+    pwmRunning.store(true, std::memory_order_relaxed);
 }
 
 void cpPwmSetDuty(uint16_t duty_raw) {
-    if (!pwmRunning)
+    if (!pwmRunning.load(std::memory_order_relaxed))
         cpPwmStart(duty_raw);
     else {
         ledcWrite(PWM_CHANNEL, duty_raw);
@@ -28,5 +29,5 @@ void cpPwmSetDuty(uint16_t duty_raw) {
 void cpPwmStop() {
     ledcWrite(PWM_CHANNEL, 0);
     cpSetLastPwmDuty(0);
-    pwmRunning = false;
+    pwmRunning.store(false, std::memory_order_relaxed);
 }


### PR DESCRIPTION
## Summary
- use atomic variables for CP monitor, PWM, and EVSE state machine
- print log messages on EVSE stage transitions
- log SLAC status periodically in the example

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883ec33f87c8324a16e224726b1090d