### PR TITLE
Fix SLAC global vars for PlatformIO example

### DIFF
--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -31,8 +31,6 @@ static inline void stageEnter(EvseStage s) {
     Serial.printf("[EVSE] Stage -> %s\n", stageName(s));
 }
 
-extern std::atomic<uint8_t> g_slac_state;
-extern std::atomic<uint32_t> g_slac_ts;
 
 static void handleIdleA() {
     if (cpGetSubState() == CP_B1) {

--- a/examples/platformio_complete/src/cp_state_machine.h
+++ b/examples/platformio_complete/src/cp_state_machine.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Arduino.h>
+#include <atomic>
 #include "cp_monitor.h"
 
 enum EvseStage : uint8_t {
@@ -17,3 +18,6 @@ void evseStateMachineInit();
 void evseStateMachineTask(void*);
 EvseStage evseGetStage();
 const char* evseStageName(EvseStage);
+
+extern std::atomic<uint8_t> g_slac_state;
+extern std::atomic<uint32_t> g_slac_ts;

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -19,11 +19,11 @@ static const uint8_t MY_MAC[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
 // Global pointer used by the polling loop
 static slac::Channel* g_channel = nullptr;
 volatile bool plc_irq = false;
-static std::atomic<uint8_t> g_slac_state{0};
+std::atomic<uint8_t> g_slac_state{0};
 
 void IRAM_ATTR plc_isr() { plc_irq = true; }
 // Timestamp for SLAC restart logic
-static std::atomic<uint32_t> g_slac_ts{0};
+std::atomic<uint32_t> g_slac_ts{0};
 
 static void logTask(void*) {
     const TickType_t period = pdMS_TO_TICKS(1000);


### PR DESCRIPTION
## Summary
- expose g_slac_state and g_slac_ts so multiple files link
- remove duplicate externs in state machine

## Testing
- `pio run` in `examples/platformio_complete`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884bab7e04c832499e91f80fa746d31