### PR TITLE
Fix FreeRTOS log task stack usage in example

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -64,7 +64,9 @@ void cpLowRateStop() {
         timerAlarmDisable(adcTimer);
 }
 
-float cpGetVoltageMv() { return static_cast<float>(cp_mv.load(std::memory_order_relaxed)); }
+uint16_t cpGetVoltageMv() {
+    return cp_mv.load(std::memory_order_relaxed);
+}
 CpSubState cpGetSubState() { return cp_state.load(std::memory_order_relaxed); }
 char cpGetStateLetter() { return toLetter(cp_state.load(std::memory_order_relaxed)); }
 

--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -8,7 +8,7 @@ void     cpMonitorInit();
 void     cpLowRateStart(uint32_t period_ms = 5);
 void     cpLowRateStop();
 
-float    cpGetVoltageMv();
+uint16_t cpGetVoltageMv();
 CpSubState cpGetSubState();
 char     cpGetStateLetter();
 

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -28,9 +28,9 @@ std::atomic<uint32_t> g_slac_ts{0};
 static void logTask(void*) {
     const TickType_t period = pdMS_TO_TICKS(1000);
     while (true) {
-        Serial.printf("[STAT] CP=%c %.2fV Stage=%s SLAC=%u\n",
-                      cpGetStateLetter(),
-                      cpGetVoltageMv() / 1000.0f,
+        uint16_t mv = cpGetVoltageMv();
+        Serial.printf("[STAT] CP=%c %u.%03u V Stage=%s SLAC=%u\n",
+                      cpGetStateLetter(), mv / 1000, mv % 1000,
                       evseStageName(evseGetStage()),
                       g_slac_state.load(std::memory_order_relaxed));
         vTaskDelay(period);
@@ -50,7 +50,7 @@ void setup() {
     cpLowRateStart(10);
     evseStateMachineInit();
     xTaskCreatePinnedToCore(evseStateMachineTask, "evseSM", 4096, nullptr, 5, nullptr, 1);
-    xTaskCreatePinnedToCore(logTask, "log", 2048, nullptr, 1, nullptr, 1);
+    xTaskCreatePinnedToCore(logTask, "log", 6144, nullptr, 1, nullptr, 0);
     SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, -1);
     Serial.println("Starting SPI");
     pinMode(PLC_INT_PIN, INPUT);


### PR DESCRIPTION
## Summary
- change CP monitor voltage accessor to return an integer
- print voltage without floats in log task
- give log task a larger stack and run it on core0

## Testing
- `pio run -d examples/platformio_complete`

------
https://chatgpt.com/codex/tasks/task_e_6884bd5291ac8324bde660ebc901619c