### PR TITLE
Support CP idle release option and compile helpers

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -17,6 +17,7 @@
 #define CP_PWM_FREQ_HZ      1000
 #define CP_PWM_RES_BITS     12
 #define CP_PWM_DUTY_5PCT    ((1 << CP_PWM_RES_BITS) * 5 / 100)
+#define CP_IDLE_RELEASE   1   // 1=open-drain idle, 0=drive high
 
 #define T_PLC_INIT_MS       700
 #define T_HLC_EST_MS        2000

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -11,6 +11,9 @@ void cpPwmInit() {
 }
 
 void cpPwmStart(uint16_t duty_raw) {
+#if CP_IDLE_RELEASE
+    ledcAttachPin(CP_PWM_OUT_PIN, PWM_CHANNEL);
+#endif
     ledcWrite(PWM_CHANNEL, duty_raw);
     cpSetLastPwmDuty(duty_raw);
     pwmRunning = true;
@@ -26,7 +29,14 @@ void cpPwmSetDuty(uint16_t duty_raw) {
 }
 
 void cpPwmStop() {
-    ledcWrite(PWM_CHANNEL, 0);
+#if CP_IDLE_RELEASE
+    ledcDetachPin(CP_PWM_OUT_PIN);
+    pinMode(CP_PWM_OUT_PIN, INPUT);
     cpSetLastPwmDuty(0);
+#else
+    uint16_t max_count = (1u << CP_PWM_RES_BITS) - 1;
+    ledcWrite(PWM_CHANNEL, max_count);
+    cpSetLastPwmDuty(max_count);
+#endif
     pwmRunning = false;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,3 +46,6 @@ build_src_filter =
     +<port/esp32s3/qca7000_link.cpp>
     +<3rd_party/hash_library/sha256.cpp>
     +<examples/platformio_complete/src/main.cpp>
+    +<examples/platformio_complete/src/cp_monitor.cpp>
+    +<examples/platformio_complete/src/cp_pwm.cpp>
+    +<examples/platformio_complete/src/cp_state_machine.cpp>


### PR DESCRIPTION
## Summary
- implement CP_IDLE_RELEASE compile-time option
- add open-drain vs push-pull logic to cp_pwm
- include CP helper sources in PlatformIO build
- verify example builds with `platformio run`

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6884c61cff4883248157e2535470290a