### PR TITLE
Fix CP PWM idle behavior and upgrade toolchain

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -17,7 +17,7 @@
 #define CP_PWM_FREQ_HZ      1000
 #define CP_PWM_RES_BITS     12
 #define CP_PWM_DUTY_5PCT    ((1 << CP_PWM_RES_BITS) * 5 / 100)
-#define CP_IDLE_RELEASE   1   // 1=open-drain idle, 0=drive high
+#define CP_IDLE_RELEASE   0   // actively drive CP high when PWM is idle
 
 #define T_PLC_INIT_MS       700
 #define T_HLC_EST_MS        2000

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -28,15 +28,10 @@ void cpPwmSetDuty(uint16_t duty_raw) {
     }
 }
 
-void cpPwmStop() {
-#if CP_IDLE_RELEASE
-    ledcDetachPin(CP_PWM_OUT_PIN);
-    pinMode(CP_PWM_OUT_PIN, INPUT);
-    cpSetLastPwmDuty(0);
-#else
-    uint16_t max_count = (1u << CP_PWM_RES_BITS) - 1;
-    ledcWrite(PWM_CHANNEL, max_count);
-    cpSetLastPwmDuty(max_count);
-#endif
+void cpPwmStop()
+{
+    constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1; // 100% duty
+    ledcWrite(PWM_CHANNEL, DUTY_FULL);   // drive CP to +12V rail
+    cpSetLastPwmDuty(0);                 // remember "PWM is OFF"
     pwmRunning = false;
 }

--- a/platformio.ini
+++ b/platformio.ini
@@ -3,9 +3,11 @@ src_dir = .
 
 
 [env:esp32s3]
-platform = espressif32 ; use ESP32 toolchain version 6.5.0
+platform = espressif32@^6.9.1 ; use 64-bit GCC toolchain
 board = esp32-s3-devkitc-1  ; target board
 framework = arduino         ; build using the Arduino core
+
+platform_packages = toolchain-xtensa-esp32s3@~12.2.0
 
 # remove the default C++11 flag
 build_unflags = -std=gnu++11


### PR DESCRIPTION
## Summary
- keep CP pin driven high when PWM is stopped
- set config to actively drive CP high
- upgrade PlatformIO toolchain to 64‑bit GCC 12.2
- confirm build using `platformio run`

## Testing
- `./run_tests.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6884ca36e6788324b753affc2106d85b