### PR TITLE
Handle CM_VALIDATE frames in SLAC

### DIFF
--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -1,23 +1,32 @@
 #include "cp_state_machine.h"
-#include "cp_pwm.h"
 #include "cp_config.h"
-#include <port/esp32s3/qca7000.hpp>
+#include "cp_pwm.h"
 #include <atomic>
+#include <port/esp32s3/qca7000.hpp>
 
 static std::atomic<EvseStage> stage{EVSE_IDLE_A};
 static std::atomic<uint32_t> t_stage{0};
 
 static const char* stageName(EvseStage s) {
     switch (s) {
-        case EVSE_IDLE_A: return "Idle";
-        case EVSE_INITIALISE_B1: return "InitialiseB1";
-        case EVSE_DIGITAL_REQ_B2: return "DigitalReqB2";
-        case EVSE_CABLE_CHECK_C: return "CableCheckC";
-        case EVSE_PRECHARGE: return "Precharge";
-        case EVSE_ENERGY_TRANSFER: return "EnergyTransfer";
-        case EVSE_POWER_DOWN: return "PowerDown";
-        case EVSE_UNLOCK_B1: return "UnlockB1";
-        default: return "?";
+    case EVSE_IDLE_A:
+        return "Idle";
+    case EVSE_INITIALISE_B1:
+        return "InitialiseB1";
+    case EVSE_DIGITAL_REQ_B2:
+        return "DigitalReqB2";
+    case EVSE_CABLE_CHECK_C:
+        return "CableCheckC";
+    case EVSE_PRECHARGE:
+        return "Precharge";
+    case EVSE_ENERGY_TRANSFER:
+        return "EnergyTransfer";
+    case EVSE_POWER_DOWN:
+        return "PowerDown";
+    case EVSE_UNLOCK_B1:
+        return "UnlockB1";
+    default:
+        return "?";
     }
 }
 
@@ -30,7 +39,6 @@ static inline void stageEnter(EvseStage s) {
     t_stage.store(0, std::memory_order_relaxed);
     Serial.printf("[EVSE] Stage -> %s\n", stageName(s));
 }
-
 
 static void handleIdleA() {
     if (cpGetSubState() == CP_B1) {
@@ -54,13 +62,11 @@ static void handleInitialiseB1() {
 }
 
 static void handleDigitalReqB2() {
-    if (g_slac_state.load(std::memory_order_relaxed) == 5 &&
-        (cpGetSubState() == CP_C || cpGetSubState() == CP_D)) {
+    if (g_slac_state.load(std::memory_order_relaxed) == 6 && (cpGetSubState() == CP_C || cpGetSubState() == CP_D)) {
         stageEnter(EVSE_CABLE_CHECK_C);
         return;
     }
-    if (t_stage.load(std::memory_order_relaxed) > T_HLC_EST_MS &&
-        g_slac_state.load(std::memory_order_relaxed) != 5) {
+    if (t_stage.load(std::memory_order_relaxed) > T_HLC_EST_MS && g_slac_state.load(std::memory_order_relaxed) != 6) {
         stageEnter(EVSE_INITIALISE_B1);
     }
 }
@@ -112,7 +118,9 @@ static void handleUnlockB1() {
     }
 }
 
-void evseStateMachineInit() { stageEnter(EVSE_IDLE_A); }
+void evseStateMachineInit() {
+    stageEnter(EVSE_IDLE_A);
+}
 
 EvseStage evseGetStage() {
     return stage.load(std::memory_order_relaxed);
@@ -123,14 +131,30 @@ void evseStateMachineTask(void*) {
     while (true) {
         EvseStage s = stage.load(std::memory_order_relaxed);
         switch (s) {
-            case EVSE_IDLE_A:          handleIdleA(); break;
-            case EVSE_INITIALISE_B1:   handleInitialiseB1(); break;
-            case EVSE_DIGITAL_REQ_B2:  handleDigitalReqB2(); break;
-            case EVSE_CABLE_CHECK_C:   handleCableCheckC(); break;
-            case EVSE_PRECHARGE:       handlePrecharge(); break;
-            case EVSE_ENERGY_TRANSFER: handleEnergyTransfer(); break;
-            case EVSE_POWER_DOWN:      handlePowerDown(); break;
-            case EVSE_UNLOCK_B1:       handleUnlockB1(); break;
+        case EVSE_IDLE_A:
+            handleIdleA();
+            break;
+        case EVSE_INITIALISE_B1:
+            handleInitialiseB1();
+            break;
+        case EVSE_DIGITAL_REQ_B2:
+            handleDigitalReqB2();
+            break;
+        case EVSE_CABLE_CHECK_C:
+            handleCableCheckC();
+            break;
+        case EVSE_PRECHARGE:
+            handlePrecharge();
+            break;
+        case EVSE_ENERGY_TRANSFER:
+            handleEnergyTransfer();
+            break;
+        case EVSE_POWER_DOWN:
+            handlePowerDown();
+            break;
+        case EVSE_UNLOCK_B1:
+            handleUnlockB1();
+            break;
         }
         t_stage.fetch_add(period, std::memory_order_relaxed);
         vTaskDelay(pdMS_TO_TICKS(period));

--- a/include/slac/fsm.hpp
+++ b/include/slac/fsm.hpp
@@ -15,6 +15,7 @@ enum class SlacEvent {
     SoundIntervalElapsed,
     GotAttenCharInd,
     GotSetKeyReq,
+    GotValidateReq,
     GotMatchReq,
     Timeout,
     Error


### PR DESCRIPTION
## Summary
- extend the SLAC event enum to include `GotValidateReq`
- add validation state in the QCA7000 SLAC FSM
- parse and respond to `CM_VALIDATE.REQ` frames
- adjust timeouts and success state number
- update example CP state machine logic

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884f7bc5fd483248c5c18949c360e3a