### PR TITLE
Implement attenuation profile accumulation

### DIFF
--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -97,6 +97,8 @@ enum class Qca7000ErrorStatus { Reset, DriverFatal };
 typedef void (*qca7000_error_cb_t)(Qca7000ErrorStatus, void*);
 void qca7000SetErrorCallback(qca7000_error_cb_t cb, void* arg, bool* flag);
 bool qca7000DriverFatal();
+void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
+                   const uint8_t evse_id[slac::messages::EVSE_ID_LEN]);
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>


### PR DESCRIPTION
## Summary
- extend `SlacContext` with storage for VIN/EVSE IDs and attenuation profile data
- add API to set VIN and EVSE IDs
- implement aggregation of `CM_ATTEN_PROFILE.IND` messages and send averaged `CM_ATTEN_CHAR.IND`
- initialize new fields when starting SLAC

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6884fd91e9f083248d460c6dd4992592