### PR TITLE
Add NMK setter for SLAC

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -15,6 +15,9 @@ extern void qca7000ProcessSlice(uint32_t max_us);
 
 // Default MAC address for the modem. Adjust as required.
 static const uint8_t MY_MAC[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+static const uint8_t EVSE_NMK[slac::defs::NMK_LEN] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
 
 // Global pointer used by the polling loop
 static slac::Channel* g_channel = nullptr;
@@ -74,6 +77,7 @@ void setup() {
         while (true)
             delay(1000);
     }
+    qca7000SetNmk(EVSE_NMK);
 
 }
 

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -95,6 +95,19 @@ void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
         memcpy(g_slac_ctx.evse_id, evse_id, sizeof(g_slac_ctx.evse_id));
 }
 
+static uint8_t g_evse_nmk[slac::defs::NMK_LEN]{};
+static uint8_t g_evse_nid[slac::defs::NID_LEN]{};
+
+void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]) {
+    if (nmk) {
+        memcpy(g_evse_nmk, nmk, sizeof(g_evse_nmk));
+        slac::utils::generate_nid_from_nmk(g_evse_nid, g_evse_nmk);
+    } else {
+        memset(g_evse_nmk, 0, sizeof(g_evse_nmk));
+        memset(g_evse_nid, 0, sizeof(g_evse_nid));
+    }
+}
+
 #ifdef LIBSLAC_TESTING
 SPIClass* g_spi = nullptr;
 int g_cs = -1;
@@ -623,9 +636,9 @@ static bool send_match_cnf(const SlacContext& ctx) {
     memcpy(msg.cnf.evse_id, ctx.match_req.evse_id, sizeof(msg.cnf.evse_id));
     memcpy(msg.cnf.evse_mac, ctx.match_req.evse_mac, sizeof(msg.cnf.evse_mac));
     memcpy(msg.cnf.run_id, ctx.match_req.run_id, sizeof(msg.cnf.run_id));
-    memset(msg.cnf.nid, 0, sizeof(msg.cnf.nid));
+    memcpy(msg.cnf.nid, g_evse_nid, sizeof(msg.cnf.nid));
     msg.cnf._reserved2 = 0;
-    memset(msg.cnf.nmk, 0, sizeof(msg.cnf.nmk));
+    memcpy(msg.cnf.nmk, g_evse_nmk, sizeof(msg.cnf.nmk));
 
     return txFrame(reinterpret_cast<uint8_t*>(&msg), sizeof(msg));
 }

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -99,6 +99,7 @@ void qca7000SetErrorCallback(qca7000_error_cb_t cb, void* arg, bool* flag);
 bool qca7000DriverFatal();
 void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
                    const uint8_t evse_id[slac::messages::EVSE_ID_LEN]);
+void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -60,3 +60,4 @@ void qca7000Process() {}
 void qca7000ProcessSlice(uint32_t) {}
 bool qca7000DriverFatal() { return false; }
 void qca7000SetErrorCallback(qca7000_error_cb_t, void*, bool*) {}
+void qca7000SetNmk(const uint8_t[slac::defs::NMK_LEN]) {}


### PR DESCRIPTION
## Summary
- allow passing an NMK to the QCA7000 driver before starting the SLAC flow
- use the NMK to compute the NID for CM_SLAC_MATCH.CNF
- call new setter in the PlatformIO example
- extend test HAL mock

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68850032741c8324835dfd8213fe55d0