### PR TITLE
Expose configurable MAC address

### DIFF
--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -98,6 +98,8 @@ enum class Qca7000ErrorStatus { Reset, DriverFatal };
 typedef void (*qca7000_error_cb_t)(Qca7000ErrorStatus, void*);
 void qca7000SetErrorCallback(qca7000_error_cb_t cb, void* arg, bool* flag);
 bool qca7000DriverFatal();
+void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
+const uint8_t* qca7000GetMac();
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -444,7 +444,16 @@ size_t spiQCA7000checkForReceivedData(uint8_t* d, size_t m) {
 }
 
 static uint8_t g_run_id[slac::defs::RUN_ID_LEN]{};
-static const uint8_t g_src_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+static uint8_t g_src_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+
+void qca7000SetMac(const uint8_t mac[ETH_ALEN]) {
+    if (mac)
+        memcpy(g_src_mac, mac, ETH_ALEN);
+}
+
+const uint8_t* qca7000GetMac() {
+    return g_src_mac;
+}
 
 static bool send_start_atten_char(const SlacContext& ctx);
 static bool send_mnbc_sound(const SlacContext& ctx, uint8_t remaining);
@@ -464,7 +473,7 @@ static bool send_start_atten_char(const SlacContext& ctx) {
 
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_START_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND);
@@ -473,7 +482,7 @@ static bool send_start_atten_char(const SlacContext& ctx) {
     msg.ind.num_sounds = slac::defs::C_EV_MATCH_MNBC;
     msg.ind.timeout = slac::defs::TT_EVSE_MATCH_MNBC_MS / 100;
     msg.ind.resp_type = slac::defs::CM_SLAC_PARM_CNF_RESP_TYPE;
-    memcpy(msg.ind.forwarding_sta, g_src_mac, ETH_ALEN);
+    memcpy(msg.ind.forwarding_sta, qca7000GetMac(), ETH_ALEN);
     memcpy(msg.ind.run_id, ctx.run_id, sizeof(ctx.run_id));
     return txFrame(reinterpret_cast<uint8_t*>(&msg), sizeof(msg));
 }
@@ -490,7 +499,7 @@ static bool send_mnbc_sound(const SlacContext& ctx, uint8_t remaining) {
 
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_MNBC_SOUND | slac::defs::MMTYPE_MODE_IND);
@@ -517,13 +526,13 @@ static bool send_atten_char_rsp(const SlacContext& ctx, const uint8_t* dst,
 
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_RSP);
     msg.rsp.application_type = slac::defs::COMMON_APPLICATION_TYPE;
     msg.rsp.security_type = slac::defs::COMMON_SECURITY_TYPE;
-    memcpy(msg.rsp.source_address, g_src_mac, ETH_ALEN);
+    memcpy(msg.rsp.source_address, qca7000GetMac(), ETH_ALEN);
     memcpy(msg.rsp.run_id, ind->run_id, sizeof(ind->run_id));
     memcpy(msg.rsp.source_id, ind->source_id, sizeof(ind->source_id));
     memcpy(msg.rsp.resp_id, ind->resp_id, sizeof(ind->resp_id));
@@ -543,7 +552,7 @@ static bool send_atten_char_ind(const SlacContext& ctx) {
 
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, ctx.pev_mac, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype =
@@ -575,7 +584,7 @@ static bool send_set_key_cnf(const SlacContext& ctx, const uint8_t* dst, const s
 
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF);
@@ -601,7 +610,7 @@ static bool send_validate_cnf(const uint8_t* dst, const slac::messages::cm_valid
 
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_CNF);
@@ -624,7 +633,7 @@ static bool send_match_cnf(const SlacContext& ctx) {
 
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, ctx.match_src_mac, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF);
@@ -807,7 +816,7 @@ bool qca7000startSlac() {
 
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
-    memcpy(msg.eth.ether_shost, g_src_mac, ETH_ALEN);
+    memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
     msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_REQ);

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -100,6 +100,8 @@ bool qca7000DriverFatal();
 void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
                    const uint8_t evse_id[slac::messages::EVSE_ID_LEN]);
 void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
+void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
+const uint8_t* qca7000GetMac();
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -12,6 +12,13 @@ Qca7000Link::Qca7000Link(const qca7000_config& c,
                          void* cb_arg)
     : cfg(c), error_cb(cb), error_arg(cb_arg) {
     memset(mac_addr, 0, sizeof(mac_addr));
+    if (cfg.mac_addr)
+        memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);
+    else {
+        const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+        memcpy(mac_addr, def_mac, ETH_ALEN);
+    }
+    qca7000SetMac(mac_addr);
 }
 
 Qca7000Link::~Qca7000Link() {
@@ -45,13 +52,8 @@ bool Qca7000Link::open() {
         return false;
     }
     qca7000SetErrorCallback(error_cb, error_arg, &fatal_error_flag);
+    qca7000SetMac(mac_addr);
 
-    if (cfg.mac_addr)
-        memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);
-    else {
-        const uint8_t def_mac[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
-        memcpy(mac_addr, def_mac, ETH_ALEN);
-    }
     initialized = true;
     return true;
 }

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -61,3 +61,5 @@ void qca7000ProcessSlice(uint32_t) {}
 bool qca7000DriverFatal() { return false; }
 void qca7000SetErrorCallback(qca7000_error_cb_t, void*, bool*) {}
 void qca7000SetNmk(const uint8_t[slac::defs::NMK_LEN]) {}
+void qca7000SetMac(const uint8_t[ETH_ALEN]) {}
+const uint8_t* qca7000GetMac() { static uint8_t mac[ETH_ALEN] = {}; return mac; }


### PR DESCRIPTION
## Summary
- allow configuring the modem MAC address via `qca7000_config`
- wire the MAC through `Qca7000Link` constructor and initialization
- expose helpers `qca7000SetMac`/`qca7000GetMac`
- update frame builders to use the configured MAC
- adapt test mocks

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68850241b86483248c449b3bb6fa0f08