### PR TITLE
Propagate LinkError from Channel::write

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,12 @@ callback and periodically check ``link.fatal_error()`` when polling the
 driver. Call ``qca7000CheckAlive()`` roughly once per minute to
 confirm that the modem is still responsive.
 
+Both ``Channel::read()`` and ``Channel::write()`` return
+``slac::transport::LinkError``. A ``Timeout`` result indicates that no
+frame was received or transmitted in the allotted time while
+``Transport`` signals a lower level failure. Applications can use these
+codes to retry the operation or reset the modem after repeated errors.
+
 QCA7000 Configuration
 ---------------------
 
@@ -204,9 +210,10 @@ provide two pieces:
    optional interrupt helpers.
 
 ``transport::Link`` exposes ``open()``, ``write()``, ``read()`` and ``mac()``.
-``open()`` should initialise the hardware and return ``true`` on success. The
-``write()`` and ``read()`` methods transfer raw frames with millisecond timeouts
-while ``mac()`` returns the local MAC address.
+``open()`` should initialise the hardware and return ``true`` on success.
+``write()`` and ``read()`` transfer raw frames with millisecond timeouts and
+return a :class:`slac::transport::LinkError` to report success, timeouts or
+transport failures. ``mac()`` returns the local MAC address.
 
 ``port_config.hpp`` is included by the library and provides platform specific
 timing helpers. A minimal bare-metal variant might look like:

--- a/examples/platformio_complete/test/test_basic.cpp
+++ b/examples/platformio_complete/test/test_basic.cpp
@@ -7,8 +7,8 @@ public:
     bool open() override {
         return true;
     }
-    bool write(const uint8_t*, size_t, uint32_t) override {
-        return true;
+    slac::transport::LinkError write(const uint8_t*, size_t, uint32_t) override {
+        return slac::transport::LinkError::Ok;
     }
     slac::transport::LinkError read(uint8_t*, size_t, size_t* out_len, uint32_t) override {
         if (out_len)

--- a/include/port/esp32s3/qca7000_link.hpp
+++ b/include/port/esp32s3/qca7000_link.hpp
@@ -37,7 +37,7 @@ public:
     void close();
 
     bool open() override;
-    bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    transport::LinkError write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
     transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 

--- a/include/port/esp32s3/qca7000_uart.hpp
+++ b/include/port/esp32s3/qca7000_uart.hpp
@@ -33,7 +33,7 @@ public:
     explicit Qca7000UartLink(const qca7000_uart_config& cfg);
 
     bool open() override;
-    bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    transport::LinkError write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
     transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -35,7 +35,7 @@ public:
     bool open();
     transport::LinkError read(slac::messages::HomeplugMessage& msg, int timeout);
     bool poll(slac::messages::HomeplugMessage& msg);
-    bool write(slac::messages::HomeplugMessage& msg, int timeout);
+    transport::LinkError write(slac::messages::HomeplugMessage& msg, int timeout);
 
     const std::string& get_error() const {
         return error;

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -17,7 +17,7 @@ enum class LinkError {
 class Link {
 public:
     virtual bool open() = 0;
-    virtual bool write(const uint8_t* buf, size_t len, uint32_t timeout_ms) = 0;
+    virtual LinkError write(const uint8_t* buf, size_t len, uint32_t timeout_ms) = 0;
     virtual LinkError read(uint8_t* buf, size_t len, size_t* out_len, uint32_t timeout_ms) = 0;
     virtual const uint8_t* mac() const = 0;
     virtual ~Link() = default;

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -58,10 +58,12 @@ bool Qca7000Link::open() {
     return true;
 }
 
-bool Qca7000Link::write(const uint8_t* b, size_t l, uint32_t) {
+transport::LinkError Qca7000Link::write(const uint8_t* b, size_t l, uint32_t) {
     if (!initialized || initialization_error)
-        return false;
-    return spiQCA7000SendEthFrame(b, l);
+        return transport::LinkError::Transport;
+    if (!spiQCA7000SendEthFrame(b, l))
+        return transport::LinkError::Transport;
+    return transport::LinkError::Ok;
 }
 
 void Qca7000Link::close() {

--- a/port/esp32s3/qca7000_link.hpp
+++ b/port/esp32s3/qca7000_link.hpp
@@ -37,7 +37,7 @@ public:
     void close();
 
     bool open() override;
-    bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    transport::LinkError write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
     transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 

--- a/port/esp32s3/qca7000_uart.cpp
+++ b/port/esp32s3/qca7000_uart.cpp
@@ -259,10 +259,12 @@ bool Qca7000UartLink::open() {
     return true;
 }
 
-bool Qca7000UartLink::write(const uint8_t* b, size_t l, uint32_t) {
+transport::LinkError Qca7000UartLink::write(const uint8_t* b, size_t l, uint32_t) {
     if (!initialized || initialization_error)
-        return false;
-    return uartQCA7000SendEthFrame(b, l);
+        return transport::LinkError::Transport;
+    if (!uartQCA7000SendEthFrame(b, l))
+        return transport::LinkError::Transport;
+    return transport::LinkError::Ok;
 }
 
 void Qca7000UartLink::close() {

--- a/port/esp32s3/qca7000_uart.hpp
+++ b/port/esp32s3/qca7000_uart.hpp
@@ -33,7 +33,7 @@ public:
     explicit Qca7000UartLink(const qca7000_uart_config& cfg);
 
     bool open() override;
-    bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    transport::LinkError write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
     transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 

--- a/tests/test_qca7000_link.cpp
+++ b/tests/test_qca7000_link.cpp
@@ -15,7 +15,7 @@ TEST(Qca7000LinkIntegration, BasicReadWrite) {
     ASSERT_TRUE(link.open());
 
     uint8_t frame[6] = {1,2,3,4,5,6};
-    EXPECT_TRUE(link.write(frame, sizeof(frame), 0));
+    EXPECT_EQ(link.write(frame, sizeof(frame), 0), slac::transport::LinkError::Ok);
 
     memcpy(myethreceivebuffer, frame, sizeof(frame));
     myethreceivelen = sizeof(frame);


### PR DESCRIPTION
## Summary
- surface detailed LinkError results
- return LinkError from link write implementations
- update documentation to describe new error reporting
- adjust tests for new return type

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885047ba2d4832497b3398d1fd85849