### PR TITLE
Expose detailed channel errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,14 @@ callback and periodically check ``link.fatal_error()`` when polling the
 driver. Call ``qca7000CheckAlive()`` roughly once per minute to
 confirm that the modem is still responsive.
 
+``Channel::read()`` and ``Channel::write()`` return a
+``slac::transport::LinkError`` describing the result.  Besides ``Ok`` and
+``Timeout`` the enumeration includes ``Transport`` for modem-level failures,
+``InvalidArgument`` when an invalid frame is supplied, ``InvalidLength`` for
+malformed packets and ``NoLink`` if the underlying ``Link`` is missing.  A
+``Transport`` or ``NoLink`` error usually indicates that the modem needs a
+reset while ``Timeout`` suggests retrying the operation.
+
 QCA7000 Configuration
 ---------------------
 

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -35,7 +35,7 @@ public:
     bool open();
     transport::LinkError read(slac::messages::HomeplugMessage& msg, int timeout);
     bool poll(slac::messages::HomeplugMessage& msg);
-    bool write(slac::messages::HomeplugMessage& msg, int timeout);
+    transport::LinkError write(slac::messages::HomeplugMessage& msg, int timeout);
 
     const std::string& get_error() const {
         return error;

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -12,6 +12,9 @@ enum class LinkError {
     Ok,
     Timeout,
     Transport,
+    InvalidArgument,
+    InvalidLength,
+    NoLink,
 };
 
 class Link {

--- a/tests/test_channel.cpp
+++ b/tests/test_channel.cpp
@@ -48,7 +48,7 @@ TEST(Channel, RoundTrip) {
     uint8_t dst[ETH_ALEN] = {0xff,0xff,0xff,0xff,0xff,0xff};
     msg.setup_ethernet_header(dst);
 
-    ASSERT_TRUE(channel.write(msg, 100));
+    ASSERT_EQ(channel.write(msg, 100), slac::transport::LinkError::Ok);
 
     slac::messages::HomeplugMessage in;
     auto err = channel.read(in, 100);
@@ -75,7 +75,7 @@ TEST(Channel, WriteAfterSetupFailure) {
     uint8_t dst[ETH_ALEN] = {0xff,0xff,0xff,0xff,0xff,0xff};
     msg.setup_ethernet_header(dst);
 
-    ASSERT_TRUE(channel.write(msg, 100));
+    ASSERT_EQ(channel.write(msg, 100), slac::transport::LinkError::Ok);
 
     const size_t big_len = sizeof(slac::messages::homeplug_message::payload) + 1;
     std::vector<uint8_t> big(big_len, 0);
@@ -84,5 +84,5 @@ TEST(Channel, WriteAfterSetupFailure) {
                                    slac::defs::MMV::AV_1_0));
     EXPECT_FALSE(msg.is_valid());
     msg.setup_ethernet_header(dst);
-    EXPECT_FALSE(channel.write(msg, 100));
+    EXPECT_EQ(channel.write(msg, 100), slac::transport::LinkError::InvalidArgument);
 }


### PR DESCRIPTION
## Summary
- propagate error codes from channel operations
- extend `transport::LinkError` with additional results
- adjust tests for new return values
- document new errors in README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885047ba2d4832497b3398d1fd85849