### PR TITLE
Handle modem timeouts by resetting

### DIFF
--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -28,6 +28,7 @@ bool qca7000ResetAndCheck() {
     reset_called = true;
     return true;
 }
+bool qca7000SoftReset() { return true; }
 uint16_t qca7000ReadInternalReg(uint16_t reg) {
     if (reg == SPI_REG_SIGNATURE)
         return mock_signature;


### PR DESCRIPTION
## Summary
- detect aborted SLAC states in `qca7000getSlacResult`
- trigger soft/hard modem reset on timeout or driver fatal condition
- expose reset hook in unit test mock

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68850a2c3f388324b8fa97b70b99db5a