### PR TITLE
Improve gtest setup instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,14 @@ Install PlatformIO via pip:
 
    pip install platformio
 
+The unit tests rely on the system provided GoogleTest libraries.  Make
+sure ``libgtest-dev`` (or an equivalent package) is installed before
+running ``run_tests.sh``:
+
+.. code-block:: bash
+
+   sudo apt-get install libgtest-dev
+
 Building with PlatformIO
 -----------------------
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 set -e
 
+# Abort early when GoogleTest headers are missing.  The unit tests rely on
+# the system provided gtest development package (e.g. ``libgtest-dev`` on
+# Debian/Ubuntu).
+if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.h ]; then
+    echo "GoogleTest headers not found. Please install libgtest-dev before running tests." >&2
+    exit 1
+fi
+
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
 SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 


### PR DESCRIPTION
## Summary
- recommend installing `libgtest-dev` with `apt`
- fail early from `run_tests.sh` when gtest headers are missing

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68850c234e2c8324b84eaf4e9db1afd1