### PR TITLE
Fix example build by using local library and sync headers

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -24,6 +24,6 @@ build_unflags = -std=gnu++11
 
 
 lib_deps =
-    https://github.com/hyndex/libslac.git
+    file://../..
     SPI
 lib_ldf_mode = deep

--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -88,16 +88,18 @@ bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
 uint8_t qca7000getSlacResult();
 // Poll the modem for events and service the RX ring.
-// When a CPU_ON or buffer error interrupt occurs the driver first
-// performs qca7000SoftReset(). If that fails the reset pin is toggled
-// via a hard reset.
+// If a CPU_ON or buffer error interrupt is detected the driver
+// attempts a soft reset via qca7000SoftReset(). Should that fail the
+// reset pin is toggled using a hard reset.
 void qca7000Process();
-void qca7000ProcessSlice(uint32_t max_us = 500);
 
 enum class Qca7000ErrorStatus { Reset, DriverFatal };
 typedef void (*qca7000_error_cb_t)(Qca7000ErrorStatus, void*);
 void qca7000SetErrorCallback(qca7000_error_cb_t cb, void* arg, bool* flag);
 bool qca7000DriverFatal();
+void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
+                   const uint8_t evse_id[slac::messages::EVSE_ID_LEN]);
+void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
 void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
 const uint8_t* qca7000GetMac();
 #ifdef ESP_PLATFORM

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -53,8 +53,8 @@ struct SlacContext {
     uint8_t validate_count{0};
     slac::messages::cm_slac_match_req match_req{};
     uint8_t match_src_mac[ETH_ALEN]{};
-    uint8_t pev_id[slac::defs::PEV_ID_LEN]{};
-    uint8_t evse_id[slac::defs::EVSE_ID_LEN]{};
+    uint8_t pev_id[slac::messages::PEV_ID_LEN]{};
+    uint8_t evse_id[slac::messages::EVSE_ID_LEN]{};
     uint8_t atten_sum[slac::defs::AAG_LIST_LEN]{};
     uint8_t atten_count{0};
     uint8_t num_groups{0};


### PR DESCRIPTION
## Summary
- use local libslac path in platformio example
- sync exported qca7000.hpp header with implementation
- fix namespace for PEV/EVSE ID constants in qca7000.cpp

## Testing
- `./run_tests.sh`
- `pio run -e esp32-s3-devkitc-1`

------
https://chatgpt.com/codex/tasks/task_e_68850cf5e3148324a70236674c4f666b