### PR TITLE
Fix EVSE example state transitions for SLAC

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -21,7 +21,7 @@
 #define CP_PWM_FREQ_HZ      1000
 #define CP_PWM_RES_BITS     12
 #define CP_PWM_DUTY_5PCT    (((1 << CP_PWM_RES_BITS) * 5 + 50) / 100) // round correctly
-#define CP_IDLE_RELEASE     0   // 0=keep pin attached and drive high when idle, 1=release
+#define CP_IDLE_RELEASE     1   // 0=keep pin attached and drive high when idle, 1=release
 #define CP_SAMPLE_OFFSET_US 25
 
 #define T_PLC_INIT_MS       700

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -38,8 +38,15 @@ void cpPwmSetDuty(uint16_t duty_raw) {
 
 void cpPwmStop()
 {
+#if CP_IDLE_RELEASE
+    ledcWrite(PWM_CHANNEL, 0);           // ensure low before detaching
+    cpSetLastPwmDuty(0);                 // duty is effectively 0
+    ledcDetachPin(CP_PWM_OUT_PIN);       // let CP float via pull-up
+    pinMode(CP_PWM_OUT_PIN, INPUT);      // high-Z idle
+#else
     constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1; // 100% duty
     ledcWrite(PWM_CHANNEL, DUTY_FULL);   // drive CP to +12V rail
     cpSetLastPwmDuty(DUTY_FULL);         // reflect actual pin level
+#endif
     pwmRunning = false;
 }


### PR DESCRIPTION
## Summary
- allow high-Z idle CP pin and detach when idle
- detect vehicle in CP_B1 or CP_B3 while idle
- start SLAC immediately and move to DigitalReqB2 without CP_B2 check
- enable CP_IDLE_RELEASE=1

## Testing
- `./run_tests.sh`
- `pio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_6885155542748324ae9629912e920f6f