### PR TITLE
Fix CP duty reporting and B-state detection

### DIFF
--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -38,8 +38,16 @@ void cpPwmSetDuty(uint16_t duty_raw) {
 
 void cpPwmStop()
 {
+#if CP_IDLE_RELEASE
+    /* Hi-Z – rely on pull-up resistor to keep CP at +12 V */
+    ledcDetachPin(CP_PWM_OUT_PIN);
+    pinMode(CP_PWM_OUT_PIN, INPUT);
+#else
+    /* Keep the output driven HIGH, but mark that no PWM is active */
     constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1; // 100% duty
-    ledcWrite(PWM_CHANNEL, DUTY_FULL);   // drive CP to +12V rail
-    cpSetLastPwmDuty(DUTY_FULL);         // reflect actual pin level
+    ledcWrite(PWM_CHANNEL, DUTY_FULL);
+#endif
+    /* Tell the monitor that the PWM is off */
+    cpSetLastPwmDuty(0);
     pwmRunning = false;
 }


### PR DESCRIPTION
## Summary
- keep PWM pin's logical state but report duty zero when PWM is stopped
- classify B1/B2/B3 sub‑states correctly in the CP monitor
- build with PlatformIO to verify firmware compiles
- run unit tests

## Testing
- `./run_tests.sh`
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68851347c99c8324917c7511bbb4091e