### PR TITLE
Fix CP monitoring state detection and start SLAC automatically

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -30,13 +30,17 @@ static CpSubState mv2state(uint16_t mv) {
         return (mv < CP_THR_NEG_F_MV) ? CP_F : CP_E;
     if (mv > CP_THR_12V_MV)
         return CP_A;
-    if (mv > CP_THR_9V_MV)
-        return (duty == 0) ? CP_B1 : CP_B3;
-    if (mv > CP_THR_6V_MV) {
-        uint16_t pct = (duty * 100) >> CP_PWM_RES_BITS;
-        if (pct >= 3 && pct <= 7) return CP_B2;
-        return CP_C;
+    if (mv > CP_THR_9V_MV) {
+        uint16_t pct = (duty * 100) >> CP_PWM_RES_BITS;   // 0-100 %
+        bool no_pwm = (pct == 0 || pct == 100);
+        if (no_pwm)
+            return CP_B1;              // static 9V
+        if (pct >= 3 && pct <= 7)
+            return CP_B2;              // 5% ± tolerance
+        return CP_B3;
     }
+    if (mv > CP_THR_6V_MV)
+        return CP_C;
     if (mv > CP_THR_3V_MV)
         return CP_D;
     return CP_E;

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -40,6 +40,6 @@ void cpPwmStop()
 {
     constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1; // 100% duty
     ledcWrite(PWM_CHANNEL, DUTY_FULL);   // drive CP to +12V rail
-    cpSetLastPwmDuty(DUTY_FULL);         // reflect actual pin level
+    cpSetLastPwmDuty(0);                 // 0% tells monitor that PWM is off
     pwmRunning = false;
 }

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -56,7 +56,7 @@ static void handleInitialiseB1() {
         cpPwmStop();
         stageEnter(EVSE_IDLE_A);
     }
-    if (cpGetSubState() == CP_B2) {
+    if (cpDigitalCommRequested()) {
         stageEnter(EVSE_DIGITAL_REQ_B2);
     }
 }


### PR DESCRIPTION
## Summary
- keep last duty at `0` when PWM stopped so monitor sees no modulation
- correctly detect 5% PWM state in the CP monitor
- accept both B2 and (mis-)detected B3 when advancing the state machine

## Testing
- `platformio run -e esp32s3`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688515b27fdc8324adf1932858fb184b