### PR TITLE
Fix CP idle handling

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -21,7 +21,7 @@
 #define CP_PWM_FREQ_HZ      1000
 #define CP_PWM_RES_BITS     12
 #define CP_PWM_DUTY_5PCT    (((1 << CP_PWM_RES_BITS) * 5 + 50) / 100) // round correctly
-#define CP_IDLE_RELEASE     1   // 0=keep pin attached and drive high when idle, 1=release
+#define CP_IDLE_RELEASE     0   // 0=keep pin attached and drive high when idle, 1=release
 #define CP_SAMPLE_OFFSET_US 25
 
 #define T_PLC_INIT_MS       700

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -41,6 +41,8 @@ static inline void stageEnter(EvseStage s) {
 }
 
 static void handleIdleA() {
+    if (t_stage.load(std::memory_order_relaxed) == 0)
+        cpPwmStop();
     CpSubState s = cpGetSubState();
     if (s == CP_B1 || s == CP_B3) {
         cpPwmStart(CP_PWM_DUTY_5PCT);


### PR DESCRIPTION
## Summary
- drive CP line high when idle to support hardware without a 12 V pull‑up
- ensure idle stage stops PWM before checking for car connection

## Testing
- `./run_tests.sh`
- `platformio run -d examples/platformio_complete`


------
https://chatgpt.com/codex/tasks/task_e_68851e83d8588324973a7053834d8075