### PR TITLE
Add SLAC match logger

### DIFF
--- a/include/slac/match_log.hpp
+++ b/include/slac/match_log.hpp
@@ -1,0 +1,30 @@
+#ifndef SLAC_MATCH_LOG_HPP
+#define SLAC_MATCH_LOG_HPP
+
+#include <stdint.h>
+#include <slac/slac.hpp>
+
+namespace slac {
+
+struct MatchLogInfo {
+    uint8_t pev_mac[ETH_ALEN];
+    uint8_t evse_mac[ETH_ALEN];
+    uint8_t nmk[defs::NMK_LEN];
+    uint8_t tone_min;
+    uint8_t tone_avg;
+    uint8_t tone_max;
+    char cp_state;
+};
+
+using match_log_fn_t = void (*)(const MatchLogInfo&);
+
+void set_match_log_fn(match_log_fn_t fn);
+match_log_fn_t get_match_log_fn();
+
+void slac_log_match(const MatchLogInfo& info);
+
+char slac_get_cp_state();
+
+} // namespace slac
+
+#endif // SLAC_MATCH_LOG_HPP

--- a/library.json
+++ b/library.json
@@ -21,6 +21,7 @@
             "+<src/channel.cpp>",
             "+<src/slac.cpp>",
             "+<src/config.cpp>",
+            "+<src/match_log.cpp>",
             "+<port/esp32s3/qca7000.cpp>",
             "+<port/esp32s3/qca7000_link.cpp>",
             "+<3rd_party/hash_library/sha256.cpp>"

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,7 +10,7 @@ if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.
 fi
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/src/match_log.cpp
+++ b/src/match_log.cpp
@@ -1,0 +1,51 @@
+#include <slac/match_log.hpp>
+#include <port/logging_compat.hpp>
+#include <port/esp32s3/qca7000.hpp>
+#include <cstdio>
+
+namespace slac {
+
+static match_log_fn_t g_log_fn = nullptr;
+
+void set_match_log_fn(match_log_fn_t fn) { g_log_fn = fn; }
+match_log_fn_t get_match_log_fn() { return g_log_fn; }
+
+__attribute__((weak)) char slac_get_cp_state() { return '?'; }
+
+#ifndef SLAC_DISABLE_MATCH_LOG
+static void default_log(const MatchLogInfo& info) {
+    char pev[18];
+    snprintf(pev, sizeof(pev), "%02X:%02X:%02X:%02X:%02X:%02X",
+             info.pev_mac[0], info.pev_mac[1], info.pev_mac[2],
+             info.pev_mac[3], info.pev_mac[4], info.pev_mac[5]);
+    char evse[18];
+    snprintf(evse, sizeof(evse), "%02X:%02X:%02X:%02X:%02X:%02X",
+             info.evse_mac[0], info.evse_mac[1], info.evse_mac[2],
+             info.evse_mac[3], info.evse_mac[4], info.evse_mac[5]);
+    char nmk_hex[defs::NMK_LEN * 2 + 1];
+    for (size_t i = 0; i < defs::NMK_LEN; ++i)
+        sprintf(&nmk_hex[i * 2], "%02X", info.nmk[i]);
+
+    ESP_LOGI(PLC_TAG, "SLAC MATCH OK");
+    ESP_LOGI(PLC_TAG, "  PEV_MAC : %s", pev);
+    ESP_LOGI(PLC_TAG, "  EVSE_MAC: %s", evse);
+    ESP_LOGI(PLC_TAG, "  TONEMAP : min=%u avg=%u max=%u",
+             info.tone_min, info.tone_avg, info.tone_max);
+    ESP_LOGI(PLC_TAG, "  NMK     : %s", nmk_hex);
+    ESP_LOGI(PLC_TAG, "  CP_STATE: %c", info.cp_state);
+}
+#endif
+
+void slac_log_match(const MatchLogInfo& info) {
+#ifdef SLAC_DISABLE_MATCH_LOG
+    (void)info;
+#else
+    if (g_log_fn) {
+        g_log_fn(info);
+    } else {
+        default_log(info);
+    }
+#endif
+}
+
+} // namespace slac


### PR DESCRIPTION
## Summary
- add `MatchLogInfo` struct and logging hook
- integrate `slac_log_match` in match confirmation
- allow runtime hook or compile-time disable
- include new file in build and tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885e3580ec483248daba3f9854ab53f