### PR TITLE
Add region-aware tone mask handling

### DIFF
--- a/docs/qca7000-bring-up.md
+++ b/docs/qca7000-bring-up.md
@@ -35,10 +35,19 @@ Running `examples/platformio_complete` on an ESP32-S3 yields output similar to:
 ```text
 Starting SLAC modem...
 Starting SPI
-Starting QCA7000 Link 
+Starting QCA7000 Link
 ```
 
 If `channel.open()` fails the example prints `Failed to open SLAC channel, aborting` and stays in an error loop.
+
+## Region Codes
+
+The modem's PIB stores a byte identifying the regulatory region. Common values are:
+
+| Code | Region |
+|-----:|-------|
+| `0x00` | Europe (CE bandplan) |
+| `0x01` | North America (FCC bandplan) |
 
 ## Logic-Analyser Traces
 

--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -106,6 +106,13 @@ void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
 void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
 void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
 const uint8_t* qca7000GetMac();
+
+enum class qca7000_region : uint8_t {
+    EU = 0x00,
+    NA = 0x01,
+};
+
+qca7000_region qca7000GetRegion();
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>


### PR DESCRIPTION
## Summary
- read region code from the PIB during `qca7000setup`
- select application type according to region when sending `CM_SLAC_PARAM.REQ`
- expose region getters in the port API
- document region codes in the bring-up guide

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885ee2e78cc83248c55255bf49b8fad