### PR TITLE
Auto install gtest in run_tests.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,9 +39,10 @@ Install PlatformIO via pip:
 
    pip install platformio
 
-The unit tests rely on the system provided GoogleTest libraries.  Make
-sure ``libgtest-dev`` (or an equivalent package) is installed before
-running ``run_tests.sh``:
+The unit tests rely on the system provided GoogleTest libraries.  When
+missing, ``run_tests.sh`` attempts to install ``libgtest-dev`` using
+``apt``.  If ``apt`` is not available install the package manually
+before running ``run_tests.sh``:
 
 .. code-block:: bash
 
@@ -264,10 +265,10 @@ Running Unit Tests
 ------------------
 
 The ``run_tests.sh`` script builds and executes the unit tests.  It
-links against the system provided GoogleTest libraries and therefore
-requires the ``libgtest-dev`` package (or an equivalent package provided
-by your distribution).  On Debian/Ubuntu based systems install the
-dependency via ``apt`` before running the script:
+links against the system provided GoogleTest libraries.  When the
+headers are missing, the script attempts to install the
+``libgtest-dev`` package via ``apt``.  If ``apt`` is unavailable,
+install the dependency manually before running the script.  For example:
 
 .. code-block:: bash
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -5,8 +5,13 @@ set -e
 # the system provided gtest development package (e.g. ``libgtest-dev`` on
 # Debian/Ubuntu).
 if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.h ]; then
-    echo "GoogleTest headers not found. Please install libgtest-dev before running tests." >&2
-    exit 1
+    echo "GoogleTest headers not found. Attempting to install libgtest-dev..." >&2
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update && sudo apt-get install -y libgtest-dev
+    else
+        echo "apt-get not available. Please install libgtest-dev manually." >&2
+        exit 1
+    fi
 fi
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"


### PR DESCRIPTION
## Summary
- install libgtest-dev automatically from run_tests.sh when missing
- note automatic install in the README

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6885f9cb08408324b76df0cb22ccbf50