### PR TITLE
Add slac_get_cp_state implementation

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -137,3 +137,10 @@ bool cpDigitalCommRequested() {
     CpSubState s = cp_state.load(std::memory_order_relaxed);
     return s == CP_B2 || s == CP_B3;
 }
+
+// Provide the runtime CP state for SLAC match logging
+#include <slac/match_log.hpp>
+
+namespace slac {
+char slac_get_cp_state() { return cpGetStateLetter(); }
+}


### PR DESCRIPTION
## Summary
- expose the CP state used during SLAC handshake logging

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6885fd536744832487e264988fb3f374