### PR TITLE
Update NID derivation

### DIFF
--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -112,7 +112,8 @@ const uint8_t BROADCAST_MAC_ADDRESS[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
 namespace utils {
 void generate_nmk_hs(uint8_t nmk_hs[slac::defs::NMK_LEN], const char* plain_password, int password_len);
-void generate_nid_from_nmk(uint8_t nid[8], const uint8_t nmk[slac::defs::NMK_LEN]);
+void generate_nid_from_nmk(uint8_t nid[8], const uint8_t nmk[slac::defs::NMK_LEN],
+                           uint8_t level = defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT);
 } // namespace utils
 
 namespace messages {

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -137,7 +137,9 @@ static qca7000_region g_region = qca7000_region::EU;
 void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]) {
     if (nmk) {
         memcpy(g_evse_nmk, nmk, sizeof(g_evse_nmk));
-        slac::utils::generate_nid_from_nmk(g_evse_nid, g_evse_nmk);
+        slac::utils::generate_nid_from_nmk(
+            g_evse_nid, g_evse_nmk,
+            slac::defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT);
     } else {
         memset(g_evse_nmk, 0, sizeof(g_evse_nmk));
         memset(g_evse_nid, 0, sizeof(g_evse_nid));

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,7 +15,7 @@ if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.
 fi
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -43,7 +43,8 @@ void generate_nmk_hs(uint8_t nmk_hs[slac::defs::NMK_LEN], const char* plain_pass
     memcpy(nmk_hs, hash, slac::defs::NMK_LEN);
 }
 
-void generate_nid_from_nmk(uint8_t nid[8], const uint8_t nmk[slac::defs::NMK_LEN]) {
+void generate_nid_from_nmk(uint8_t nid[8], const uint8_t nmk[slac::defs::NMK_LEN],
+                           uint8_t level) {
     SHA256 sha256;
 
     // msb of least significant octet of NMK should be the leftmost bit
@@ -62,9 +63,10 @@ void generate_nid_from_nmk(uint8_t nid[8], const uint8_t nmk[slac::defs::NMK_LEN
     // use leftmost 52 bits of the hash output
     // left most bit should be bit 7 of the nid
     memcpy(nid, hash, 6); // (bits 52 - 5)
-    nid[6] = (slac::defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT << slac::defs::NID_SECURITY_LEVEL_OFFSET) |
-             ((static_cast<uint8_t>(hash[6])) >> slac::defs::NID_MOST_SIGNIFANT_BYTE_SHIFT);
-    nid[7] = 0;
+    nid[6] = (level << slac::defs::NID_SECURITY_LEVEL_OFFSET) |
+             ((static_cast<uint8_t>(hash[6]) & 0xF0) >> slac::defs::NID_MOST_SIGNIFANT_BYTE_SHIFT);
+    if (slac::defs::NID_LEN == 8)
+        nid[7] = 0;
 }
 
 } // namespace utils

--- a/tests/test_nid.cpp
+++ b/tests/test_nid.cpp
@@ -1,0 +1,17 @@
+#include <gtest/gtest.h>
+#include <slac/slac.hpp>
+#include <cstring>
+
+using namespace slac;
+
+TEST(NID, GenerateKnownValue) {
+    uint8_t nmk[defs::NMK_LEN];
+    for (int i = 0; i < defs::NMK_LEN; ++i)
+        nmk[i] = i; // 0x00,0x01,...0x0f
+    uint8_t nid[defs::NID_LEN]{};
+    utils::generate_nid_from_nmk(nid, nmk, defs::NID_SECURITY_LEVEL_SIMPLE_CONNECT);
+    const uint8_t expected[] = {0x4d, 0x30, 0xa0, 0xf8, 0x45, 0x5d, 0x0b};
+    ASSERT_EQ(memcmp(nid, expected, sizeof(expected)), 0);
+}
+
+


### PR DESCRIPTION
## Summary
- allow specifying security level for `generate_nid_from_nmk`
- compute final NID byte using security level
- keep zero padding when `NID_LEN` equals 8
- test NID calculation for a fixed NMK

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68860bb075b08324addbeae386a1ef7a