### PR TITLE
Fix PlatformIO build

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -25,6 +25,6 @@ build_unflags = -std=gnu++11
 extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =
-    https://github.com/hyndex/libslac.git
+    ../../
     SPI
 lib_ldf_mode = deep

--- a/platformio.ini
+++ b/platformio.ini
@@ -44,6 +44,7 @@ build_src_filter =
     +<src/channel.cpp>
     +<src/slac.cpp>
     +<src/config.cpp>
+    +<src/match_log.cpp>
     +<port/esp32s3/qca7000.cpp>
     +<port/esp32s3/qca7000_link.cpp>
     +<3rd_party/hash_library/sha256.cpp>

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1,6 +1,6 @@
-#include "qca7000.hpp"
+#include "../../include/port/esp32s3/qca7000.hpp"
 #include "../port_common.hpp"
-#include "port_config.hpp"
+#include <port/esp32s3/port_config.hpp>
 #include <slac/config.hpp>
 #ifdef ESP_LOGW
 #pragma push_macro("ESP_LOGW")
@@ -60,6 +60,10 @@ static constexpr uint16_t INTR_MASK = SPI_INT_CPU_ON | SPI_INT_PKT_AVLBL | SPI_I
 
 using FSMBuffer = slac::fsm::buffer::SwapBuffer<64, 0, 1>;
 using FSM = slac::fsm::FSM<slac::SlacEvent, int, FSMBuffer>;
+
+// Forward declarations
+static bool txFrame(const uint8_t* eth, size_t ethLen);
+void qca7000ProcessSlice(uint32_t max_us);
 
 struct SlacContext {
     uint8_t run_id[slac::defs::RUN_ID_LEN]{};
@@ -823,7 +827,7 @@ static bool send_match_cnf(const SlacContext& ctx) {
     info.tone_min = (ctx.num_groups ? min : 0);
     info.tone_max = (ctx.num_groups ? max : 0);
     info.tone_avg = (ctx.num_groups ? (sum / ctx.num_groups) : 0);
-    info.cp_state = slac_get_cp_state();
+    info.cp_state = slac::slac_get_cp_state();
 
     slac::slac_log_match(info);
 

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -1,7 +1,7 @@
-#include "qca7000_link.hpp"
+#include "../../include/port/esp32s3/qca7000_link.hpp"
 #include "../port_common.hpp"
-#include "port_config.hpp"
-#include "qca7000.hpp"
+#include "../../include/port/esp32s3/port_config.hpp"
+#include "../../include/port/esp32s3/qca7000.hpp"
 #include <cstring>
 
 namespace slac {


### PR DESCRIPTION
## Summary
- include match log source so builds link
- use library from repo for example
- include headers from `include/` tree in port sources
- add forward declarations for QCA7000 implementation

## Testing
- `pio run -e esp32s3`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6886137f3e008324aa171f8becb99759