### PR TITLE
Fix PlatformIO example build

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -25,6 +25,6 @@ build_unflags = -std=gnu++11
 extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =
-    https://github.com/hyndex/libslac.git
+    ../../
     SPI
 lib_ldf_mode = deep

--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -79,6 +79,8 @@ bool qca7000setup(SPIClass* spi, int cs_pin, int rst_pin = PLC_SPI_RST_PIN);
 void qca7000teardown();
 bool qca7000ResetAndCheck();
 bool qca7000SoftReset();
+// Leave the current AVLN and reset internal state.
+bool qca7000LeaveAvln();
 uint16_t qca7000ReadInternalReg(uint16_t reg);
 bool qca7000ReadSignature(uint16_t* sig = nullptr, uint16_t* ver = nullptr);
 // Poll a few internal registers to verify that the modem is responsive.

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1,6 +1,6 @@
-#include "qca7000.hpp"
+#include <port/esp32s3/qca7000.hpp>
 #include "../port_common.hpp"
-#include "port_config.hpp"
+#include <port/esp32s3/port_config.hpp>
 #include <slac/config.hpp>
 #ifdef ESP_LOGW
 #pragma push_macro("ESP_LOGW")
@@ -47,6 +47,10 @@ uint8_t myethtransmitbuffer[V2GTP_BUFFER_SIZE]{};
 size_t myethtransmitlen = 0;
 uint8_t myethreceivebuffer[V2GTP_BUFFER_SIZE]{};
 size_t myethreceivelen = 0;
+
+// Forward declarations
+static bool txFrame(const uint8_t* eth, size_t ethLen);
+void qca7000ProcessSlice(uint32_t max_us);
 
 static constexpr uint16_t SIG = 0xAA55;
 static constexpr uint16_t WRBUF_RST = 0x0C5B;
@@ -823,7 +827,7 @@ static bool send_match_cnf(const SlacContext& ctx) {
     info.tone_min = (ctx.num_groups ? min : 0);
     info.tone_max = (ctx.num_groups ? max : 0);
     info.tone_avg = (ctx.num_groups ? (sum / ctx.num_groups) : 0);
-    info.cp_state = slac_get_cp_state();
+    info.cp_state = slac::slac_get_cp_state();
 
     slac::slac_log_match(info);
 


### PR DESCRIPTION
## Summary
- include qca7000LeaveAvln in public headers
- avoid private headers when building the ESP32S3 port
- add prototypes needed by qca7000.cpp
- use local libslac copy for PlatformIO example

## Testing
- `./run_tests.sh`
- `pio run -e esp32-s3-devkitc-1`

------
https://chatgpt.com/codex/tasks/task_e_688617cf41e88324be3a75381846dec4