### PR TITLE
fix: gate PLC-watchdog on PWM state to avoid false link-lost in Idle

### DIFF
--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -5,6 +5,8 @@
 static bool pwmRunning = false;
 static constexpr uint8_t PWM_CHANNEL = 0;
 
+bool cpPwmIsRunning() { return pwmRunning; }
+
 void cpPwmInit() {
     ledcSetup(PWM_CHANNEL, CP_PWM_FREQ_HZ, CP_PWM_RES_BITS);
     ledcAttachPin(CP_PWM_OUT_PIN, PWM_CHANNEL);

--- a/examples/platformio_complete/src/cp_pwm.h
+++ b/examples/platformio_complete/src/cp_pwm.h
@@ -6,3 +6,4 @@ void cpPwmInit();
 void cpPwmStart(uint16_t duty_raw = CP_PWM_DUTY_5PCT);
 void cpPwmStop();
 void cpPwmSetDuty(uint16_t duty_raw);
+bool cpPwmIsRunning();

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -133,8 +133,10 @@ void loop() {
         // Handle incoming SLAC messages here
     }
 
-    // Detect PLC link loss while CP duty cycle > 5% (X2)
-    if (cpGetLastPwmDuty() > CP_PWM_DUTY_5PCT && !qca7000CheckAlive()) {
+    // Detect PLC link loss only when digital comms are active
+    if (cpPwmIsRunning() &&
+        cpDigitalCommRequested() &&
+        !qca7000CheckAlive()) {
         Serial.println("[PLC] link lost");
         hlc_stop();
         qca7000LeaveAvln();


### PR DESCRIPTION
## Summary
- expose PWM running flag via `cpPwmIsRunning`
- tighten PLC watchdog condition to check PWM and CP state

## Testing
- `run_tests.sh`
- `platformio run -v` *(fails: `qca7000_region` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_6886278ff848832495cb17f62093abd7