### PR TITLE
Add fetchRx SPI mock tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -15,7 +15,7 @@ if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.
 fi
 
 CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/test_qca7000_fetch_rx.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -12,18 +12,35 @@ struct SPISettings {
     SPISettings(uint32_t, uint8_t, uint8_t) {}
 };
 
+using transfer_cb_t = uint8_t (*)(uint8_t);
+using transfer16_cb_t = uint16_t (*)(uint16_t);
+using write_cb_t = void (*)(const uint8_t*, size_t);
+
+extern transfer_cb_t g_transfer_cb;
+extern transfer16_cb_t g_transfer16_cb;
+extern write_cb_t g_write_cb;
+
 class SPIClass {
 public:
     void begin() {}
     void beginTransaction(const SPISettings&) {}
     void endTransaction() {}
-    uint8_t transfer(uint8_t) { return 0; }
-    uint16_t transfer16(uint16_t) { return 0; }
-    void writeBytes(const uint8_t*, size_t) {}
+    uint8_t transfer(uint8_t v) { return g_transfer_cb ? g_transfer_cb(v) : 0; }
+    uint16_t transfer16(uint16_t v) {
+        return g_transfer16_cb ? g_transfer16_cb(v) : 0;
+    }
+    void writeBytes(const uint8_t* d, size_t l) {
+        if (g_write_cb)
+            g_write_cb(d, l);
+    }
 };
 
 extern SPIClass SPI;
 inline SPIClass SPI;
+
+inline transfer_cb_t g_transfer_cb = nullptr;
+inline transfer16_cb_t g_transfer16_cb = nullptr;
+inline write_cb_t g_write_cb = nullptr;
 
 inline void pinMode(int, int) {}
 inline void digitalWrite(int, int) {}

--- a/tests/test_qca7000_fetch_rx.cpp
+++ b/tests/test_qca7000_fetch_rx.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+#define ARDUINO
+#include "arduino_stubs.hpp"
+#include "port/esp32s3/qca7000.hpp"
+
+extern "C" void mock_ring_reset();
+extern "C" void mock_spi_feed_raw(const uint8_t*, size_t);
+extern bool soft_reset_called;
+void fetchRx();
+
+TEST(Qca7000FetchRx, ValidFrameParsing) {
+    mock_ring_reset();
+    soft_reset_called = false;
+    uint8_t eth[6] = {1,2,3,4,5,6};
+    const uint16_t fl = sizeof(eth);
+    const uint16_t total = 12 + fl + 2;
+    uint8_t raw[32] = {};
+    raw[0] = total & 0xFF;
+    raw[1] = total >> 8;
+    raw[2] = 0; raw[3] = 0;
+    raw[4] = 0xAA; raw[5] = 0xAA; raw[6] = 0xAA; raw[7] = 0xAA;
+    raw[8] = fl & 0xFF; raw[9] = fl >> 8;
+    raw[10] = 0; raw[11] = 0;
+    memcpy(raw + 12, eth, fl);
+    raw[12 + fl] = 0x55;
+    raw[13 + fl] = 0x55;
+    mock_spi_feed_raw(raw, total);
+    fetchRx();
+
+    uint8_t buf[16];
+    size_t got = spiQCA7000checkForReceivedData(buf, sizeof(buf));
+    ASSERT_EQ(got, sizeof(eth));
+    EXPECT_EQ(0, memcmp(buf, eth, sizeof(eth)));
+    EXPECT_FALSE(soft_reset_called);
+}
+
+TEST(Qca7000FetchRx, FrameErrorTriggersReset) {
+    mock_ring_reset();
+    soft_reset_called = false;
+    uint8_t eth[6] = {1,2,3,4,5,6};
+    const uint16_t fl = sizeof(eth);
+    const uint16_t total = 12 + fl + 2;
+    uint8_t raw[32] = {};
+    raw[0] = total & 0xFF;
+    raw[1] = total >> 8;
+    raw[2] = 0; raw[3] = 0;
+    raw[4] = 0xAA; raw[5] = 0xAA; raw[6] = 0xAA; raw[7] = 0xAA;
+    raw[8] = fl & 0xFF; raw[9] = fl >> 8;
+    raw[10] = 0; raw[11] = 0;
+    memcpy(raw + 12, eth, fl);
+    raw[12 + fl] = 0x00; // corrupt EOF
+    raw[13 + fl] = 0x00;
+    mock_spi_feed_raw(raw, total);
+    fetchRx();
+
+    uint8_t buf[16];
+    size_t got = spiQCA7000checkForReceivedData(buf, sizeof(buf));
+    EXPECT_EQ(got, 0u);
+    EXPECT_TRUE(soft_reset_called);
+}


### PR DESCRIPTION
## Summary
- extend arduino stubs with hook callbacks
- enhance qca7000 HAL mock with SPI read simulation and reset detection
- add unit tests for fetchRx parsing and error handling
- run tests including new suite

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68877ab6add083249b0662fe6322215e