### PR TITLE
Ensure MULTI_CS bit cleared after soft reset

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -504,6 +504,11 @@ static void handleRxError(const char* reason) {
         ESP_LOGW(PLC_TAG, "Soft reset failed - performing hard reset");
         hardReset();
     }
+    uint16_t cfg = qca7000ReadInternalReg(SPI_REG_SPI_CONFIG);
+    if (cfg & QCASPI_MULTI_CS_BIT) {
+        ESP_LOGW(PLC_TAG, "MULTI_CS bit set after reset");
+        spiWr16_slow(SPI_REG_SPI_CONFIG, cfg & ~QCASPI_MULTI_CS_BIT);
+    }
     head.store(0, std::memory_order_relaxed);
     tail.store(0, std::memory_order_relaxed);
     spiWr16_slow(SPI_REG_INTR_ENABLE, INTR_MASK);


### PR DESCRIPTION
## Summary
- extend reset helper to check `SPI_REG_SPI_CONFIG`
- clear the `QCASPI_MULTI_CS_BIT` if legacy mode is detected
- warn when MULTI_CS was unexpectedly set

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68877d41df80832481dc6c3264bd03ed