### PR TITLE
Manage power state on EVSE transitions

### DIFF
--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -125,7 +125,6 @@ static void handlePowerDown() {
 static void handleUnlockB1() {
     cpPwmStart(CP_PWM_DUTY_5PCT); // hold 9V while waiting for unplug
     if (cpGetSubState() == CP_A) {
-        qca7000Sleep();
         stageEnter(EVSE_IDLE_A);
     }
 }


### PR DESCRIPTION
## Summary
- avoid redundant `qca7000Sleep` call when leaving the UnlockB1 stage
- maintain modem power control via `qca7000Wake` and `qca7000Sleep` on state transitions

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688787d799fc8324ba49e5acb68f10c6