### PR TITLE
Fix QCA7000 init crash and ensure build

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -93,16 +93,8 @@ void setup() {
     pinMode(CONTACTOR_FB_PIN, INPUT_PULLUP);
     pinMode(ISOLATION_OK_PIN, INPUT_PULLUP);
 
-    cpPwmInit();
-    cpMonitorInit();
-    cpLowRateStart();
-    evseStateMachineInit();
-    xTaskCreatePinnedToCore(evseStateMachineTask, "evseSM", 4096, nullptr, 5, nullptr, 1);
-    xTaskCreatePinnedToCore(logTask, "log", 4096, nullptr, 1, nullptr, 1);
     SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, -1);
     Serial.println("Starting SPI");
-    pinMode(PLC_INT_PIN, INPUT);
-    attachInterrupt(PLC_INT_PIN, plc_isr, FALLING);
     qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, g_mac_addr};
     Serial.println("Starting QCA7000 Link ");
     static slac::port::Qca7000Link link(cfg);
@@ -118,7 +110,16 @@ void setup() {
         while (true)
             delay(1000);
     }
+    pinMode(PLC_INT_PIN, INPUT);
+    attachInterrupt(PLC_INT_PIN, plc_isr, FALLING);
     qca7000SetNmk(EVSE_NMK);
+
+    cpPwmInit();
+    cpMonitorInit();
+    cpLowRateStart();
+    evseStateMachineInit();
+    xTaskCreatePinnedToCore(evseStateMachineTask, "evseSM", 4096, nullptr, 5, nullptr, 1);
+    xTaskCreatePinnedToCore(logTask, "log", 4096, nullptr, 1, nullptr, 1);
 
 }
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -46,6 +46,7 @@ build_src_filter =
     +<src/config.cpp>
     +<port/esp32s3/qca7000.cpp>
     +<port/esp32s3/qca7000_link.cpp>
+    +<src/match_log.cpp>
     +<3rd_party/hash_library/sha256.cpp>
     +<examples/platformio_complete/src/main.cpp>
     +<examples/platformio_complete/src/cp_monitor.cpp>

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -46,8 +46,15 @@
 #define QCA7000_MAX_RETRIES 3
 #endif
 
+#ifndef CONFIG_RX_RING_SIZE
+#define CONFIG_RX_RING_SIZE 8
+#endif
+
 #ifndef PLC_PWR_EN_PIN
 #define PLC_PWR_EN_PIN -1
+#endif
+#ifndef PLC_INT_PIN
+#define PLC_INT_PIN -1
 #endif
 
 #ifndef PLC_SPI_CS_PIN

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -92,6 +92,7 @@ size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
 uint8_t qca7000getSlacResult();
+void qca7000ToggleCpEf();
 // Poll the modem for events and service the RX ring.
 // If a CPU_ON or buffer error interrupt is detected the driver
 // attempts a soft reset via qca7000SoftReset(). Should that fail the
@@ -107,6 +108,13 @@ void qca7000SetIds(const uint8_t pev_id[slac::messages::PEV_ID_LEN],
 void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
 void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
 const uint8_t* qca7000GetMac();
+
+enum class qca7000_region : uint8_t {
+    EU = 0x00,
+    NA = 0x01,
+};
+
+qca7000_region qca7000GetRegion();
 #ifdef ESP_PLATFORM
 #include <freertos/FreeRTOS.h>
 #include <freertos/queue.h>


### PR DESCRIPTION
## Summary
- reorder initialization of SLAC modem so SPI/QCA7000 setup happens before tasks start
- expose missing symbols in port headers
- include match_log.cpp so examples link

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_68879d3b32748324a0b5f3347034dddb