### PR TITLE
Handle QCA7000 frames with headerless LEN

### DIFF
--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -540,17 +540,24 @@ static void fetchRx() {
         g_spi->endTransaction();
 
         const uint8_t* p = buf;
-        uint32_t len = (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+        uint32_t len = (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+                        ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+        bool len_excludes_hdr = false;
         if (len != requested) {
-            ESP_LOGE(PLC_TAG, "RX len mismatch: req=%u got=%u", requested, len);
-            handleRxError("length mismatch");
-            break;
+            if (len + 4 == requested) {
+                len_excludes_hdr = true;
+            } else {
+                ESP_LOGE(PLC_TAG, "RX len mismatch: req=%u got=%u", requested, len);
+                handleRxError("length mismatch");
+                break;
+            }
         }
         if (memcmp(p + 4, "\xAA\xAA\xAA\xAA", 4) != 0) {
             handleRxError("bad SOF");
             break;
         }
-        uint16_t fl = slac::le16toh(static_cast<uint16_t>((p[9] << 8) | p[8]));
+        uint16_t fl = len_excludes_hdr ? static_cast<uint16_t>(len - 10)
+                                       : slac::le16toh(static_cast<uint16_t>((p[9] << 8) | p[8]));
         if (fl > avail - RX_HDR - FTR_LEN) {
             handleRxError("invalid FL");
             break;

--- a/tests/test_qca7000_fetch_rx.cpp
+++ b/tests/test_qca7000_fetch_rx.cpp
@@ -34,6 +34,34 @@ TEST(Qca7000FetchRx, ValidFrameParsing) {
     EXPECT_FALSE(soft_reset_called);
 }
 
+TEST(Qca7000FetchRx, LenExcludesHeader) {
+    mock_ring_reset();
+    soft_reset_called = false;
+    uint8_t eth[6] = {1,2,3,4,5,6};
+    const uint16_t fl = sizeof(eth);
+    const uint16_t total = 12 + fl + 2;
+    const uint16_t len_no_hdr = total - 4;
+    uint8_t raw[32] = {};
+    raw[0] = len_no_hdr & 0xFF;
+    raw[1] = len_no_hdr >> 8;
+    raw[2] = 0;
+    raw[3] = 0;
+    raw[4] = 0xAA; raw[5] = 0xAA; raw[6] = 0xAA; raw[7] = 0xAA;
+    raw[8] = fl & 0xFF; raw[9] = fl >> 8;
+    raw[10] = 0; raw[11] = 0;
+    memcpy(raw + 12, eth, fl);
+    raw[12 + fl] = 0x55;
+    raw[13 + fl] = 0x55;
+    mock_spi_feed_raw(raw, total);
+    fetchRx();
+
+    uint8_t buf[16];
+    size_t got = spiQCA7000checkForReceivedData(buf, sizeof(buf));
+    ASSERT_EQ(got, sizeof(eth));
+    EXPECT_EQ(0, memcmp(buf, eth, sizeof(eth)));
+    EXPECT_FALSE(soft_reset_called);
+}
+
 TEST(Qca7000FetchRx, FrameErrorTriggersReset) {
     mock_ring_reset();
     soft_reset_called = false;


### PR DESCRIPTION
## Summary
- relax length check in `fetchRx()` for SPI receive path
- compute frame length when LEN excludes header
- extend HAL mock accordingly
- test frame parsing when LEN omits the header

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887a7eb511883248c45200546a4907a