### PR TITLE
Remove ARDUINO defines in tests

### DIFF
--- a/tests/test_bcb_wakeup.cpp
+++ b/tests/test_bcb_wakeup.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_check_alive.cpp
+++ b/tests/test_check_alive.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_qca7000_fetch_rx.cpp
+++ b/tests/test_qca7000_fetch_rx.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_qca7000_link.cpp
+++ b/tests/test_qca7000_link.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000_link.hpp"
 #include "port/esp32s3/qca7000.hpp"

--- a/tests/test_qca7000_reset.cpp
+++ b/tests/test_qca7000_reset.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_reset.cpp
+++ b/tests/test_reset.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_rx_ring.cpp
+++ b/tests/test_rx_ring.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 

--- a/tests/test_slac_filter.cpp
+++ b/tests/test_slac_filter.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 #include <slac/slac.hpp>

--- a/tests/test_slac_retry.cpp
+++ b/tests/test_slac_retry.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 #include <slac/iso15118_consts.hpp>

--- a/tests/test_validation.cpp
+++ b/tests/test_validation.cpp
@@ -1,5 +1,4 @@
 #include <gtest/gtest.h>
-#define ARDUINO
 #include "arduino_stubs.hpp"
 #include "port/esp32s3/qca7000.hpp"
 #include <slac/slac.hpp>


### PR DESCRIPTION
## Summary
- drop redundant `#define ARDUINO` from test sources
- run tests to ensure build succeeds without redefinition warnings

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6887af35a180832497a4e03ec6894a72