### PR TITLE
Correct sample offset calculation

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -21,7 +21,8 @@
 #define CP_PWM_RES_BITS     12
 #define CP_PWM_DUTY_5PCT    ((1u << CP_PWM_RES_BITS) / 20)
 #define CP_IDLE_DRIVE_HIGH  1   // 1=keep CP driven high when idle, 0=release
-#define CP_SAMPLE_OFFSET_US ((1000 / CP_PWM_FREQ_HZ) * CP_PWM_DUTY_5PCT / 2)
+#define CP_SAMPLE_OFFSET_US \
+    ((1000000 / CP_PWM_FREQ_HZ) * CP_PWM_DUTY_5PCT / (1u << CP_PWM_RES_BITS) / 2)
 
 #define T_PLC_INIT_MS       700
 #define T_HLC_EST_MS        2000


### PR DESCRIPTION
## Summary
- compute CP_SAMPLE_OFFSET_US from real PWM period
- rebuild firmware for `esp32s3`

## Testing
- `platformio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_6887b72f739c8324ba0ab00aa7e69847