### PR TITLE
Add DMA-based CP monitoring option

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -1,6 +1,10 @@
 #pragma once
 #include <stdint.h>
 
+#ifndef CP_USE_DMA_ADC
+#define CP_USE_DMA_ADC 0
+#endif
+
 #define CP_PWM_OUT_PIN      38
 #define CP_READ_ADC_PIN     1
 #define LOCK_FB_PIN         10

--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -4,6 +4,9 @@
 #include <driver/timer.h>
 #include <esp_intr_alloc.h>
 #include <esp_adc/adc_oneshot.h>
+#if CP_USE_DMA_ADC
+#include <esp_adc/adc_continuous.h>
+#endif
 #include <soc/ledc_struct.h>
 
 static hw_timer_t* adcTimer = nullptr;   // low rate timer
@@ -14,12 +17,27 @@ static std::atomic<uint16_t> cp_duty{0};
 static std::atomic<CpSubState> cp_state{CP_A};
 static DRAM_ATTR adc_oneshot_unit_handle_t adc_handle = nullptr;
 static adc_channel_t cp_channel;
+static adc_unit_t   cp_unit;
+#if CP_USE_DMA_ADC
+static adc_continuous_handle_t dma_handle = nullptr;
+static hw_timer_t* dmaTimer = nullptr;
+static constexpr uint32_t DMA_SAMPLE_RATE = 25000;
+static constexpr uint32_t DMA_SAMPLES = DMA_SAMPLE_RATE / CP_PWM_FREQ_HZ;
+static uint16_t dma_ring[DMA_SAMPLES];
+static uint32_t dma_idx = 0;
+#endif
 
 static inline uint16_t adc_oneshot_read_inline() {
     int raw = 0;
     adc_oneshot_read(adc_handle, cp_channel, &raw);
     return static_cast<uint16_t>((raw * 3300) / 4095);
 }
+
+#if CP_USE_DMA_ADC
+static inline uint16_t raw_to_mv(uint16_t raw) {
+    return static_cast<uint16_t>((raw * 3300) / 4095);
+}
+#endif
 
 static char toLetter(CpSubState s) {
     switch (s) {
@@ -72,6 +90,28 @@ static void IRAM_ATTR sample_isr() {
     cp_state.store(mv2state(v), std::memory_order_relaxed);
 }
 
+#if CP_USE_DMA_ADC
+static void IRAM_ATTR dma_timer_isr() {
+    uint8_t buf[DMA_SAMPLES * sizeof(adc_digi_output_data_t)];
+    uint32_t len = 0;
+    esp_err_t rc = adc_continuous_read(dma_handle, buf, sizeof(buf), &len, 0);
+    size_t n = len / sizeof(adc_digi_output_data_t);
+    for (size_t i = 0; i < n; ++i) {
+        auto* d = reinterpret_cast<adc_digi_output_data_t*>(buf + i * sizeof(adc_digi_output_data_t));
+        dma_ring[dma_idx++] = d->type1.data;
+        if (dma_idx >= DMA_SAMPLES)
+            dma_idx = 0;
+    }
+    uint16_t vmax = 0;
+    for (size_t i = 0; i < DMA_SAMPLES; ++i)
+        if (dma_ring[i] > vmax)
+            vmax = dma_ring[i];
+    uint16_t mv = raw_to_mv(vmax);
+    cp_mv.store(mv, std::memory_order_relaxed);
+    cp_state.store(mv2state(mv), std::memory_order_relaxed);
+}
+#endif
+
 static void IRAM_ATTR ledc_isr(void*) {
     LEDC.int_clr.lstimer0_ovf = 1;
     if (sampleTimer) {
@@ -83,6 +123,7 @@ static void IRAM_ATTR ledc_isr(void*) {
 void cpMonitorInit() {
     adc_unit_t unit;
     adc_oneshot_io_to_channel(CP_READ_ADC_PIN, &unit, &cp_channel);
+    cp_unit = unit;
     adc_oneshot_unit_init_cfg_t unit_cfg{.unit_id = unit, .ulp_mode = ADC_ULP_MODE_DISABLE};
     adc_oneshot_new_unit(&unit_cfg, &adc_handle);
     adc_oneshot_chan_cfg_t chan_cfg{.atten = ADC_ATTEN_DB_11, .bitwidth = ADC_BITWIDTH_12};
@@ -133,6 +174,48 @@ void cpFastSampleStop() {
     if (sampleTimer)
         timerAlarmDisable(sampleTimer);
 }
+
+#if CP_USE_DMA_ADC
+void cpDmaStart() {
+    if (dma_handle)
+        return;
+    adc_continuous_handle_cfg_t cfg{.max_store_buf_size = 1024,
+                                   .conv_frame_size = DMA_SAMPLES * sizeof(adc_digi_output_data_t)};
+    adc_continuous_new_handle(&cfg, &dma_handle);
+
+    adc_digi_pattern_config_t pattern{};
+    pattern.atten = ADC_ATTEN_DB_11;
+    pattern.channel = cp_channel;
+    pattern.unit = cp_unit;
+    pattern.bit_width = ADC_BITWIDTH_12;
+
+    adc_continuous_config_t dig_cfg{};
+    dig_cfg.sample_freq_hz = DMA_SAMPLE_RATE;
+    dig_cfg.conv_mode = (cp_unit == ADC_UNIT_1) ? ADC_CONV_SINGLE_UNIT_1 : ADC_CONV_SINGLE_UNIT_2;
+    dig_cfg.format = ADC_DIGI_OUTPUT_FORMAT_TYPE1;
+    dig_cfg.adc_pattern = &pattern;
+    dig_cfg.pattern_num = 1;
+
+    adc_continuous_config(dma_handle, &dig_cfg);
+    adc_continuous_start(dma_handle);
+
+    if (!dmaTimer)
+        dmaTimer = timerBegin(4, 80, true);
+    timerAttachInterrupt(dmaTimer, &dma_timer_isr, true);
+    timerAlarmWrite(dmaTimer, 1000, true);
+    timerAlarmEnable(dmaTimer);
+}
+
+void cpDmaStop() {
+    if (dmaTimer)
+        timerAlarmDisable(dmaTimer);
+    if (dma_handle) {
+        adc_continuous_stop(dma_handle);
+        adc_continuous_deinit(dma_handle);
+        dma_handle = nullptr;
+    }
+}
+#endif
 
 uint16_t cpGetVoltageMv() { return cp_mv.load(std::memory_order_relaxed); }
 CpSubState cpGetSubState() { return cp_state.load(std::memory_order_relaxed); }

--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -9,6 +9,13 @@ void     cpLowRateStart(uint32_t period_ms = 5);
 void     cpLowRateStop();
 void     cpFastSampleStart();
 void     cpFastSampleStop();
+#if CP_USE_DMA_ADC
+void     cpDmaStart();
+void     cpDmaStop();
+#else
+static inline void cpDmaStart() {}
+static inline void cpDmaStop() {}
+#endif
 
 uint16_t cpGetVoltageMv();
 CpSubState cpGetSubState();


### PR DESCRIPTION
## Summary
- support optional DMA ADC mode for CP monitoring
- implement `cpDmaStart()` and `cpDmaStop()`
- expose the new API in `cp_monitor.h`
- default the mode to disabled in `cp_config.h`

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887bae8f6ec8324b83bc67ab6b603d4