### PR TITLE
Add CP monitor unit tests with ADC mocks

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,8 +14,8 @@ if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.
     fi
 fi
 
-CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/test_qca7000_fetch_rx.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -DCP_USE_DMA_ADC=1 -DportTICK_PERIOD_MS=1 -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -Iexamples/platformio_complete/src -I. -Wduplicated-cond -Wduplicated-branches"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/test_qca7000_fetch_rx.cpp tests/test_cp_monitor.cpp tests/cp_monitor_mocks.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp examples/platformio_complete/src/cp_monitor.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -50,3 +50,5 @@ inline uint32_t micros() { return g_mock_millis * 1000; }
 inline void delay(unsigned int ms) { g_mock_millis += ms; }
 inline void noInterrupts() {}
 inline void interrupts() {}
+extern int g_mock_adc_mv;
+inline int analogReadMilliVolts(int) { return g_mock_adc_mv; }

--- a/tests/cp_monitor_mocks.cpp
+++ b/tests/cp_monitor_mocks.cpp
@@ -1,0 +1,77 @@
+#include <cstring>
+#include "driver/timer.h"
+#include "esp_intr_alloc.h"
+#include "driver/ledc.h"
+#include "esp_adc/adc_oneshot.h"
+#include "esp_adc/adc_continuous.h"
+#include "arduino_stubs.hpp"
+
+extern "C" {
+
+// ----- Timer stubs -----
+struct hw_timer_s {
+    void (*isr)();
+};
+static hw_timer_s timer_storage[8];
+void (*g_last_isr)(void) = nullptr;
+uint64_t g_last_alarm_value = 0;
+
+hw_timer_t* timerBegin(int timer, uint16_t, bool) {
+    if (timer < 0 || timer >= 8) return nullptr;
+    return &timer_storage[timer];
+}
+void timerAttachInterrupt(hw_timer_t* t, void (*fn)(), bool) {
+    if (t) t->isr = fn;
+    g_last_isr = fn;
+}
+void timerAlarmWrite(hw_timer_t*, uint64_t val, bool) { g_last_alarm_value = val; }
+void timerAlarmEnable(hw_timer_t*) {}
+void timerAlarmDisable(hw_timer_t*) {}
+void timerWrite(hw_timer_t*, uint64_t) {}
+
+// ----- LEDC ISR stub -----
+ledc_dev_t LEDC{};
+static intr_handle_t ledc_handle = nullptr;
+static void (*ledc_cb)(void*) = nullptr;
+
+esp_err_t ledc_isr_register(void (*fn)(void*), void* arg, int, intr_handle_t* handle) {
+    ledc_cb = fn;
+    ledc_handle = reinterpret_cast<intr_handle_t>(0x1);
+    if (handle) *handle = ledc_handle;
+    (void)arg;
+    return ESP_OK;
+}
+
+esp_err_t esp_intr_free(intr_handle_t) { return ESP_OK; }
+
+// ----- ADC one-shot stubs -----
+int g_adc_raw_value = 0;
+
+int adc_oneshot_io_to_channel(int, adc_unit_t* unit, adc_channel_t* chan) {
+    if (unit) *unit = ADC_UNIT_1; if (chan) *chan = 0; return 0; }
+int adc_oneshot_new_unit(const adc_oneshot_unit_init_cfg_t*, adc_oneshot_unit_handle_t* out) { if (out) *out = (void*)1; return 0; }
+int adc_oneshot_config_channel(adc_oneshot_unit_handle_t, adc_channel_t, const adc_oneshot_chan_cfg_t*) { return 0; }
+int adc_oneshot_read(adc_oneshot_unit_handle_t, adc_channel_t, int* out) { if (out) *out = g_adc_raw_value; return 0; }
+
+// ----- ADC continuous stubs -----
+uint8_t* g_dma_read_data = nullptr;
+uint32_t g_dma_read_len = 0;
+
+int adc_continuous_new_handle(const adc_continuous_handle_cfg_t*, adc_continuous_handle_t* out) { if (out) *out = (void*)1; return 0; }
+int adc_continuous_config(adc_continuous_handle_t, const adc_continuous_config_t*) { return 0; }
+int adc_continuous_start(adc_continuous_handle_t) { return 0; }
+int adc_continuous_stop(adc_continuous_handle_t) { return 0; }
+int adc_continuous_deinit(adc_continuous_handle_t) { return 0; }
+int adc_continuous_read(adc_continuous_handle_t, uint8_t* buf, uint32_t len, uint32_t* outlen, int) {
+    if (!g_dma_read_data) { if (outlen) *outlen = 0; return 0; }
+    uint32_t copy = g_dma_read_len;
+    if (copy > len) copy = len;
+    memcpy(buf, g_dma_read_data, copy);
+    if (outlen) *outlen = copy;
+    return 0;
+}
+
+} // extern "C"
+
+int g_mock_adc_mv = 0;
+

--- a/tests/driver/ledc.h
+++ b/tests/driver/ledc.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdint.h>
+#include "esp_intr_alloc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    struct { uint32_t lstimer0_ovf; } int_ena;
+    struct { uint32_t lstimer0_ovf; uint32_t val; } int_clr;
+    struct { uint32_t val; } int_st;
+} ledc_dev_t;
+
+extern ledc_dev_t LEDC;
+
+esp_err_t ledc_isr_register(void (*fn)(void*), void* arg, int flags, intr_handle_t* handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/driver/timer.h
+++ b/tests/driver/timer.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct hw_timer_s hw_timer_t;
+
+hw_timer_t* timerBegin(int timer, uint16_t divider, bool countUp);
+void timerAttachInterrupt(hw_timer_t* timer, void (*fn)(), bool edge);
+void timerAlarmWrite(hw_timer_t* timer, uint64_t alarm_value, bool auto_reload);
+void timerAlarmEnable(hw_timer_t* timer);
+void timerAlarmDisable(hw_timer_t* timer);
+void timerWrite(hw_timer_t* timer, uint64_t val);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/esp_adc/adc_continuous.h
+++ b/tests/esp_adc/adc_continuous.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* adc_continuous_handle_t;
+
+typedef struct {
+    uint32_t max_store_buf_size;
+    uint32_t conv_frame_size;
+} adc_continuous_handle_cfg_t;
+
+typedef struct {
+    int atten;
+    int channel;
+    int unit;
+    int bit_width;
+} adc_digi_pattern_config_t;
+
+typedef struct {
+    uint32_t sample_freq_hz;
+    int conv_mode;
+    int format;
+    adc_digi_pattern_config_t* adc_pattern;
+    uint32_t pattern_num;
+} adc_continuous_config_t;
+
+typedef struct {
+    struct { uint16_t data; } type1;
+} adc_digi_output_data_t;
+
+#define ADC_CONV_SINGLE_UNIT_1 0
+#define ADC_CONV_SINGLE_UNIT_2 1
+#define ADC_DIGI_OUTPUT_FORMAT_TYPE1 0
+
+int adc_continuous_new_handle(const adc_continuous_handle_cfg_t*, adc_continuous_handle_t*);
+int adc_continuous_config(adc_continuous_handle_t, const adc_continuous_config_t*);
+int adc_continuous_start(adc_continuous_handle_t);
+int adc_continuous_stop(adc_continuous_handle_t);
+int adc_continuous_deinit(adc_continuous_handle_t);
+int adc_continuous_read(adc_continuous_handle_t, uint8_t* buf, uint32_t len, uint32_t* outlen, int timeout_ms);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/esp_adc/adc_oneshot.h
+++ b/tests/esp_adc/adc_oneshot.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* adc_oneshot_unit_handle_t;
+typedef int adc_unit_t;
+typedef int adc_channel_t;
+
+typedef struct { int unit_id; int ulp_mode; } adc_oneshot_unit_init_cfg_t;
+typedef struct { int atten; int bitwidth; } adc_oneshot_chan_cfg_t;
+
+#define ADC_UNIT_1 1
+#define ADC_ATTEN_DB_11 0
+#define ADC_BITWIDTH_12 12
+#define ADC_ULP_MODE_DISABLE 0
+
+int adc_oneshot_io_to_channel(int pin, adc_unit_t* unit, adc_channel_t* chan);
+int adc_oneshot_new_unit(const adc_oneshot_unit_init_cfg_t* cfg, adc_oneshot_unit_handle_t* ret);
+int adc_oneshot_config_channel(adc_oneshot_unit_handle_t, adc_channel_t, const adc_oneshot_chan_cfg_t*);
+int adc_oneshot_read(adc_oneshot_unit_handle_t, adc_channel_t, int* out);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/esp_intr_alloc.h
+++ b/tests/esp_intr_alloc.h
@@ -1,0 +1,21 @@
+#pragma once
+#include <stdint.h>
+
+#define IRAM_ATTR
+#define DRAM_ATTR
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void* intr_handle_t;
+typedef int esp_err_t;
+
+#define ESP_INTR_FLAG_IRAM 1
+#define ESP_OK 0
+
+esp_err_t esp_intr_free(intr_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/soc/ledc_struct.h
+++ b/tests/soc/ledc_struct.h
@@ -1,0 +1,2 @@
+#pragma once
+#include "driver/ledc.h"

--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -1,0 +1,48 @@
+#include <gtest/gtest.h>
+#define ARDUINO
+#include "Arduino.h"
+
+#include "cp_monitor.h"
+#include "esp_adc/adc_continuous.h"
+
+extern "C" {
+extern uint64_t g_last_alarm_value;
+extern void (*g_last_isr)(void);
+extern uint8_t* g_dma_read_data;
+extern uint32_t g_dma_read_len;
+}
+
+static void reset_mocks() {
+    g_last_alarm_value = 0;
+    g_last_isr = nullptr;
+    g_dma_read_data = nullptr;
+    g_dma_read_len = 0;
+}
+
+TEST(CpMonitor, FastSampleSchedulesOffset) {
+    reset_mocks();
+    cpFastSampleStart();
+    EXPECT_EQ(g_last_alarm_value, CP_SAMPLE_OFFSET_US);
+}
+
+TEST(CpMonitor, DmaPeakDetection) {
+    reset_mocks();
+    cpMonitorInit();
+    cpDmaStart();
+    ASSERT_NE(g_last_isr, nullptr);
+
+    adc_digi_output_data_t buf[5] = {};
+    buf[0].type1.data = 50;
+    buf[1].type1.data = 1000;
+    buf[2].type1.data = 3000; // max
+    buf[3].type1.data = 1500;
+    buf[4].type1.data = 20;
+
+    g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
+    g_dma_read_len = sizeof(buf);
+
+    g_last_isr();
+
+    uint16_t expected_mv = static_cast<uint16_t>((3000u * 3300) / 4095);
+    EXPECT_EQ(cpGetVoltageMv(), expected_mv);
+}


### PR DESCRIPTION
## Summary
- add stubbed headers and mocks for ESP ADC and timer APIs
- extend Arduino stubs with `analogReadMilliVolts`
- compile cp_monitor.cpp with DMA support during tests
- verify timer offset scheduling in `cpFastSampleStart`
- test DMA peak detection logic

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887bcb1e72883249183e8254a9a7670