### PR TITLE
Fix PlatformIO build for ESP32 S3

### DIFF
--- a/examples/platformio_complete/lib/libcbv2g/lib/cbv2g/CMakeLists.txt
+++ b/examples/platformio_complete/lib/libcbv2g/lib/cbv2g/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_C_STANDARD 99)
 add_library(cbv2g_exi_codec)
 add_library(cbv2g::exi_codec ALIAS cbv2g_exi_codec)
 set_property(TARGET cbv2g_exi_codec PROPERTY EXPORT_NAME exi_codec)
@@ -19,7 +20,6 @@ target_include_directories(cbv2g_exi_codec
         ${PROJECT_SOURCE_DIR}/include
 )
 
-target_compile_features(cbv2g_exi_codec PRIVATE c_std_99)
 
 add_library(cbv2g_din)
 add_library(cbv2g::din ALIAS cbv2g_din)
@@ -46,7 +46,6 @@ target_link_libraries(cbv2g_din
         cbv2g::exi_codec
 )
 
-target_compile_features(cbv2g_din PUBLIC c_std_99)
 
 add_library(cbv2g_iso2)
 add_library(cbv2g::iso2 ALIAS cbv2g_iso2)
@@ -73,7 +72,6 @@ target_link_libraries(cbv2g_iso2
         cbv2g::exi_codec
 )
 
-target_compile_features(cbv2g_iso2 PUBLIC c_std_99)
 
 add_library(cbv2g_iso20)
 add_library(cbv2g::iso20 ALIAS cbv2g_iso20)
@@ -112,7 +110,6 @@ target_link_libraries(cbv2g_iso20
         cbv2g::exi_codec
 )
 
-target_compile_features(cbv2g_iso20 PUBLIC c_std_99)
 
 add_library(cbv2g_tp)
 add_library(cbv2g::tp ALIAS cbv2g_tp)
@@ -130,4 +127,3 @@ target_include_directories(cbv2g_tp
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
-target_compile_features(cbv2g_tp PUBLIC c_std_99)


### PR DESCRIPTION
## Summary
- remove `target_compile_features` from cbv2g CMake and set C99
- simplify CP monitor ADC code to use Arduino API
- allow tests to keep using ADC stubs

## Testing
- `./run_tests.sh`
- `pio run`

------
https://chatgpt.com/codex/tasks/task_e_6887c0c0d33083249940472dba6ab87a