### PR TITLE
Improve CP PWM sampling and filtering

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -5,14 +5,18 @@
 enum CpSubState : uint8_t { CP_A, CP_B1, CP_B2, CP_B3, CP_C, CP_D, CP_E, CP_F };
 
 void     cpMonitorInit();
+#if CP_USE_DMA_ADC
+void     cpLowRateStart(uint32_t period_ms = 5);
+void     cpLowRateStop();
+static inline void cpFastSampleStart() {}
+static inline void cpFastSampleStop() {}
+void     cpDmaStart();
+void     cpDmaStop();
+#else
 void     cpLowRateStart(uint32_t period_ms = 5);
 void     cpLowRateStop();
 void     cpFastSampleStart();
 void     cpFastSampleStop();
-#if CP_USE_DMA_ADC
-void     cpDmaStart();
-void     cpDmaStop();
-#else
 static inline void cpDmaStart() {}
 static inline void cpDmaStop() {}
 #endif


### PR DESCRIPTION
## Summary
- adjust PWM start/stop to control interrupts and DMA
- ramp duty cycle when changing duty
- dynamically align ADC sample timer with PWM duty
- add median filter and debounced state updates
- conditionally compile fast sampling when DMA disabled

## Testing
- `platformio run`

------
https://chatgpt.com/codex/tasks/task_e_6887d9a16700832496b274e95d8965ed