### PR TITLE
Update CP monitor sample timing

### DIFF
--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -21,8 +21,11 @@ static void reset_mocks() {
 
 TEST(CpMonitor, FastSampleSchedulesOffset) {
     reset_mocks();
+    cpSetLastPwmDuty(CP_PWM_DUTY_5PCT);
     cpFastSampleStart();
-    EXPECT_EQ(g_last_alarm_value, CP_SAMPLE_OFFSET_US);
+    uint32_t period = 1000000 / CP_PWM_FREQ_HZ;
+    uint32_t expected = ((period * CP_PWM_DUTY_5PCT) >> CP_PWM_RES_BITS) / 2;
+    EXPECT_EQ(g_last_alarm_value, expected);
 }
 
 TEST(CpMonitor, DmaPeakDetection) {


### PR DESCRIPTION
## Summary
- compute CP sampling offset based on the PWM duty cycle
- update `cpSetLastPwmDuty` and `cpFastSampleStart` to refresh the offset
- adjust cp_monitor unit test for the dynamic offset

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887dd58d35883249a500af8fa220ee0