### PR TITLE
Enable LEDC interrupt on start

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -164,6 +164,7 @@ void cpFastSampleStart() {
             ledcIsrHandle = nullptr;
         } else {
             LEDC.int_clr.val = LEDC.int_st.val;
+            LEDC.int_ena.lstimer0_ovf = 1;
         }
     }
 }
@@ -172,6 +173,7 @@ void cpFastSampleStop() {
     if (ledcIsrHandle) {
         esp_intr_free(ledcIsrHandle);
         ledcIsrHandle = nullptr;
+        LEDC.int_ena.lstimer0_ovf = 0;
     }
     if (sampleTimer)
         timerAlarmDisable(sampleTimer);

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -10,7 +10,6 @@ bool cpPwmIsRunning() { return pwmRunning; }
 void cpPwmInit() {
     ledcSetup(PWM_CHANNEL, CP_PWM_FREQ_HZ, CP_PWM_RES_BITS);
     ledcAttachPin(CP_PWM_OUT_PIN, PWM_CHANNEL);
-    LEDC.int_ena.lstimer0_ovf = 1;
     cpPwmStop();
 }
 


### PR DESCRIPTION
## Summary
- only enable the LEDC timer overflow interrupt once PWM sampling actually starts
- disable the interrupt when stopping fast sampling

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887defce32c832489b2dbb08c178bab