### PR TITLE
Lightweight cp monitor ISR and processing task

### DIFF
--- a/tests/freertos/FreeRTOS.h
+++ b/tests/freertos/FreeRTOS.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <stdint.h>
+#define pdTRUE 1
+#define pdFALSE 0
+#define pdMS_TO_TICKS(ms) (ms)
+typedef void* TimerHandle_t;
+typedef void (*TimerCallbackFunction_t)(TimerHandle_t);

--- a/tests/freertos/timers.h
+++ b/tests/freertos/timers.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "FreeRTOS.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+TimerHandle_t xTimerCreate(const char* name, uint32_t period, int auto_reload, void* arg, TimerCallbackFunction_t cb);
+void xTimerStart(TimerHandle_t timer, uint32_t ticks);
+void xTimerStop(TimerHandle_t timer, uint32_t ticks);
+void xTimerChangePeriod(TimerHandle_t timer, uint32_t ticks, uint32_t block);
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- simplify `onAdc()` to capture one ADC sample and push it into a circular buffer
- add FreeRTOS timer callback to compute a median-of-3 from buffered samples
- start/stop the processing timer together with the ADC timer
- provide FreeRTOS timer stubs for unit tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6887e14ddcb483248430f3da6770e92e