### PR TITLE
Use power management lock for PWM

### DIFF
--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -1,19 +1,29 @@
 #include "cp_pwm.h"
 #include "cp_monitor.h"
+#include <esp_pm.h>
 #include <soc/ledc_struct.h>
 
 static bool pwmRunning = false;
 static constexpr uint8_t PWM_CHANNEL = 0;
+static esp_pm_lock_handle_t cp_pm_lock = nullptr;
 
-bool cpPwmIsRunning() { return pwmRunning; }
+bool cpPwmIsRunning() {
+    return pwmRunning;
+}
 
 void cpPwmInit() {
+    if (!cp_pm_lock)
+        esp_pm_lock_create(ESP_PM_APB_FREQ_MAX, 0, "cp_pwm", &cp_pm_lock);
     ledcSetup(PWM_CHANNEL, CP_PWM_FREQ_HZ, CP_PWM_RES_BITS);
     ledcAttachPin(CP_PWM_OUT_PIN, PWM_CHANNEL);
     cpPwmStop();
 }
 
 void cpPwmStart(uint16_t duty_raw) {
+#ifdef ESP_PLATFORM
+    if (cp_pm_lock)
+        esp_pm_lock_acquire(cp_pm_lock);
+#endif
 #if !CP_IDLE_DRIVE_HIGH
     ledcAttachPin(CP_PWM_OUT_PIN, PWM_CHANNEL);
 #endif
@@ -42,8 +52,7 @@ void cpPwmSetDuty(uint16_t duty_raw) {
     }
 }
 
-void cpPwmStop()
-{
+void cpPwmStop() {
 #if CP_IDLE_DRIVE_HIGH
     constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1;
     ledcWrite(PWM_CHANNEL, DUTY_FULL);
@@ -60,4 +69,8 @@ void cpPwmStop()
     cpFastSampleStop();
 #endif
     pwmRunning = false;
+#ifdef ESP_PLATFORM
+    if (cp_pm_lock)
+        esp_pm_lock_release(cp_pm_lock);
+#endif
 }


### PR DESCRIPTION
## Summary
- use `esp_pm_lock_handle_t` to prevent APB frequency changes when PWM is active

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68889c9f5dac8324b83ff0dfbd53529a