### PR TITLE
Adjust CP monitor thresholds

### DIFF
--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -11,11 +11,11 @@
 #define CP_THR_12V_MV   2350
 #define CP_THR_9V_MV    1950
 #define CP_THR_6V_MV    1650
-#define CP_THR_3V_MV    1400
+#define CP_THR_3V_MV    1350
 #define CP_THR_1V_MV    200          // ≈ 1 V after divider
 
 // threshold for the negative plateau (-12 V -> state E/F)
-#define CP_THR_NEG12      80
+#define CP_THR_NEG12      900
 // hysteresis for negative detection (in mV)
 #define CP_THR_NEG12_HYS  30
 #define CP_THR_NEG12_LOW  (CP_THR_NEG12 - CP_THR_NEG12_HYS)


### PR DESCRIPTION
## Summary
- raise negative-plateau detection threshold to 900 mV and keep hysteresis at 30 mV
- lower 3 V state threshold to 1350 mV

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_688dfecdb90c8324844788263fcf2798