### PR TITLE
Debounce CP monitor samples before committing state

### DIFF
--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -27,10 +27,11 @@ TEST(CpMonitor, DmaPeakDetection) {
     buf[3].type1.data = 1500;
     buf[4].type1.data = 20;
 
-    g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
-    g_dma_read_len = sizeof(buf);
-
-    cpMonitorTestProcess();
+    for (int i = 0; i < 3; ++i) {
+        g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
+        g_dma_read_len = sizeof(buf);
+        cpMonitorTestProcess();
+    }
 
     uint16_t expected_mv = static_cast<uint16_t>((3000u * 3300) / 4095);
     EXPECT_EQ(cpGetVoltageMv(), expected_mv);


### PR DESCRIPTION
## Summary
- Track last ADC sample, stability counter, and timestamp in the control pilot monitor
- Only update voltage and state after three identical samples
- Adjust unit test to feed three consecutive identical frames

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e45c832848324aef6289f852ff928