### PR TITLE
Initialize CP monitor from DMA samples

### DIFF
--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -19,7 +19,14 @@ static void reset_mocks() {
 
 TEST(CpMonitor, DmaPeakDetection) {
     reset_mocks();
+    // Provide initial frame for cpMonitorInit()
+    adc_digi_output_data_t initbuf[1] = {};
+    initbuf[0].type1.data = 0;
+    g_dma_read_data = reinterpret_cast<uint8_t*>(initbuf);
+    g_dma_read_len = sizeof(initbuf);
+
     cpMonitorInit();
+
     adc_digi_output_data_t buf[5] = {};
     buf[0].type1.data = 50;
     buf[1].type1.data = 1000;


### PR DESCRIPTION
## Summary
- Initialize control-pilot voltage and state from first DMA frame instead of `analogReadMilliVolts`
- Start ADC, wait for frame, then spawn monitoring task
- Adjust cp monitor unit test for new initialization behavior

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e539a85e4832484644a2faf03e75f