### PR TITLE
Add DMA-based VOUT monitoring

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -8,6 +8,7 @@ void     cpMonitorInit();
 void     cpMonitorStop();
 
 uint16_t cpGetVoltageMv();
+uint16_t voutGetVoltageMv();
 CpSubState cpGetSubState();
 char     cpGetStateLetter();
 

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -107,7 +107,7 @@ static void handlePrecharge() {
         stageEnter(EVSE_POWER_DOWN);
     }
     // converter output scaled to ADC range (~3.3V = ~400V)
-    if (analogReadMilliVolts(VOUT_MON_ADC_PIN) > 3300) {
+    if (voutGetVoltageMv() > 3300) {
         stageEnter(EVSE_ENERGY_TRANSFER);
     }
 }

--- a/tests/esp_adc/adc_continuous.h
+++ b/tests/esp_adc/adc_continuous.h
@@ -28,7 +28,11 @@ typedef struct {
 } adc_continuous_config_t;
 
 typedef struct {
-    struct { uint16_t data; } type1;
+    struct {
+        uint16_t data;
+        uint8_t channel;
+        uint8_t _pad;
+    } type1;
 } adc_digi_output_data_t;
 
 #define ADC_CONV_SINGLE_UNIT_1 0

--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -5,6 +5,11 @@
 #include "cp_monitor.h"
 #include "esp_adc/adc_continuous.h"
 
+#include "cp_config.h"
+
+static constexpr uint8_t CP_CH = CP_READ_ADC_PIN - 1;
+static constexpr uint8_t VOUT_CH = VOUT_MON_ADC_PIN - 1;
+
 extern "C" {
 extern uint8_t* g_dma_read_data;
 extern uint32_t g_dma_read_len;
@@ -22,17 +27,18 @@ TEST(CpMonitor, DmaPeakDetection) {
     // Provide initial frame for cpMonitorInit()
     adc_digi_output_data_t initbuf[1] = {};
     initbuf[0].type1.data = 0;
+    initbuf[0].type1.channel = CP_CH;
     g_dma_read_data = reinterpret_cast<uint8_t*>(initbuf);
     g_dma_read_len = sizeof(initbuf);
 
     cpMonitorInit();
 
     adc_digi_output_data_t buf[5] = {};
-    buf[0].type1.data = 50;
-    buf[1].type1.data = 1000;
-    buf[2].type1.data = 3000; // max
-    buf[3].type1.data = 1500;
-    buf[4].type1.data = 20;
+    buf[0].type1.data = 50;   buf[0].type1.channel = CP_CH;
+    buf[1].type1.data = 1000; buf[1].type1.channel = CP_CH;
+    buf[2].type1.data = 3000; buf[2].type1.channel = CP_CH; // max
+    buf[3].type1.data = 1500; buf[3].type1.channel = CP_CH;
+    buf[4].type1.data = 20;   buf[4].type1.channel = CP_CH;
 
     g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
     g_dma_read_len = sizeof(buf);
@@ -41,4 +47,30 @@ TEST(CpMonitor, DmaPeakDetection) {
 
     uint16_t expected_mv = static_cast<uint16_t>((3000u * 3300) / 4095);
     EXPECT_EQ(cpGetVoltageMv(), expected_mv);
+}
+
+TEST(CpMonitor, VoutMeasurement) {
+    reset_mocks();
+    adc_digi_output_data_t initbuf[2] = {};
+    initbuf[0].type1.channel = CP_CH;
+    initbuf[0].type1.data = 0;
+    initbuf[1].type1.channel = VOUT_CH;
+    initbuf[1].type1.data = 0;
+    g_dma_read_data = reinterpret_cast<uint8_t*>(initbuf);
+    g_dma_read_len = sizeof(initbuf);
+
+    cpMonitorInit();
+
+    adc_digi_output_data_t buf[4] = {};
+    buf[0].type1.channel = VOUT_CH; buf[0].type1.data = 1000;
+    buf[1].type1.channel = VOUT_CH; buf[1].type1.data = 3000;
+    buf[2].type1.channel = CP_CH;   buf[2].type1.data = 0;
+    buf[3].type1.channel = CP_CH;   buf[3].type1.data = 0;
+    g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
+    g_dma_read_len = sizeof(buf);
+
+    cpMonitorTestProcess();
+
+    uint16_t expected_mv = static_cast<uint16_t>(((1000u + 3000u) / 2u * 3300) / 4095);
+    EXPECT_EQ(voutGetVoltageMv(), expected_mv);
 }


### PR DESCRIPTION
## Summary
- Extend CP monitor to continuously sample VOUT via DMA on a second ADC channel
- Provide `voutGetVoltageMv()` accessor and use it in EVSE precharge logic
- Add unit tests covering new VOUT measurement path

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_688e559aec3483248723e8570d1cbf4e