### PR TITLE
Replace analogRead stub with DMA mock

### DIFF
--- a/tests/arduino_stubs.hpp
+++ b/tests/arduino_stubs.hpp
@@ -50,5 +50,3 @@ inline uint32_t micros() { return g_mock_millis * 1000; }
 inline void delay(unsigned int ms) { g_mock_millis += ms; }
 inline void noInterrupts() {}
 inline void interrupts() {}
-extern int g_mock_adc_mv;
-inline int analogReadMilliVolts(int) { return g_mock_adc_mv; }

--- a/tests/cp_monitor_mocks.cpp
+++ b/tests/cp_monitor_mocks.cpp
@@ -1,26 +1,37 @@
 #include <cstring>
 #include "esp_adc/adc_continuous.h"
-#include "arduino_stubs.hpp"
+#include "cp_monitor_mocks.hpp"
+
+static const adc_digi_output_data_t* g_dma_data = nullptr;
+static size_t g_dma_count = 0;
 
 extern "C" {
-uint8_t* g_dma_read_data = nullptr;
-uint32_t g_dma_read_len = 0;
-
 int adc_continuous_new_handle(const adc_continuous_handle_cfg_t*, adc_continuous_handle_t* out) { if (out) *out = (void*)1; return 0; }
 int adc_continuous_config(adc_continuous_handle_t, const adc_continuous_config_t*) { return 0; }
 int adc_continuous_start(adc_continuous_handle_t) { return 0; }
 int adc_continuous_stop(adc_continuous_handle_t) { return 0; }
 int adc_continuous_deinit(adc_continuous_handle_t) { return 0; }
 int adc_continuous_read(adc_continuous_handle_t, uint8_t* buf, uint32_t len, uint32_t* outlen, int) {
-    if (!g_dma_read_data) { if (outlen) *outlen = 0; return 0; }
-    uint32_t copy = g_dma_read_len;
-    if (copy > len) copy = len;
-    memcpy(buf, g_dma_read_data, copy);
-    if (outlen) *outlen = copy;
-    g_dma_read_data = nullptr;
-    g_dma_read_len = 0;
+    if (!g_dma_data) {
+        if (outlen) *outlen = 0;
+        return 0;
+    }
+    uint32_t byte_len = static_cast<uint32_t>(g_dma_count * sizeof(adc_digi_output_data_t));
+    if (byte_len > len) byte_len = len;
+    std::memcpy(buf, g_dma_data, byte_len);
+    if (outlen) *outlen = byte_len;
+    g_dma_data = nullptr;
+    g_dma_count = 0;
     return 0;
 }
+
+void adcMockSetDmaData(const adc_digi_output_data_t* samples, size_t count) {
+    g_dma_data = samples;
+    g_dma_count = count;
 }
 
-int g_mock_adc_mv = 0;
+void adcMockReset() {
+    g_dma_data = nullptr;
+    g_dma_count = 0;
+}
+}

--- a/tests/cp_monitor_mocks.hpp
+++ b/tests/cp_monitor_mocks.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <cstddef>
+#include "esp_adc/adc_continuous.h"
+
+extern "C" {
+void adcMockSetDmaData(const adc_digi_output_data_t* samples, size_t count);
+void adcMockReset();
+}

--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -4,22 +4,15 @@
 
 #include "cp_monitor.h"
 #include "esp_adc/adc_continuous.h"
+#include "cp_monitor_mocks.hpp"
 
 #include "cp_config.h"
 
 static constexpr uint8_t CP_CH = CP_READ_ADC_PIN - 1;
 static constexpr uint8_t VOUT_CH = VOUT_MON_ADC_PIN - 1;
 
-extern "C" {
-extern uint8_t* g_dma_read_data;
-extern uint32_t g_dma_read_len;
-}
-extern int g_mock_adc_mv;
-
 static void reset_mocks() {
-    g_dma_read_data = nullptr;
-    g_dma_read_len = 0;
-    g_mock_adc_mv = 0;
+    adcMockReset();
 }
 
 TEST(CpMonitor, DmaPeakDetection) {
@@ -28,8 +21,7 @@ TEST(CpMonitor, DmaPeakDetection) {
     adc_digi_output_data_t initbuf[1] = {};
     initbuf[0].type1.data = 0;
     initbuf[0].type1.channel = CP_CH;
-    g_dma_read_data = reinterpret_cast<uint8_t*>(initbuf);
-    g_dma_read_len = sizeof(initbuf);
+    adcMockSetDmaData(initbuf, 1);
 
     cpMonitorInit();
 
@@ -40,8 +32,7 @@ TEST(CpMonitor, DmaPeakDetection) {
     buf[3].type1.data = 1500; buf[3].type1.channel = CP_CH;
     buf[4].type1.data = 20;   buf[4].type1.channel = CP_CH;
 
-    g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
-    g_dma_read_len = sizeof(buf);
+    adcMockSetDmaData(buf, 5);
 
     cpMonitorTestProcess();
 
@@ -56,8 +47,7 @@ TEST(CpMonitor, VoutMeasurement) {
     initbuf[0].type1.data = 0;
     initbuf[1].type1.channel = VOUT_CH;
     initbuf[1].type1.data = 0;
-    g_dma_read_data = reinterpret_cast<uint8_t*>(initbuf);
-    g_dma_read_len = sizeof(initbuf);
+    adcMockSetDmaData(initbuf, 2);
 
     cpMonitorInit();
 
@@ -66,8 +56,7 @@ TEST(CpMonitor, VoutMeasurement) {
     buf[1].type1.channel = VOUT_CH; buf[1].type1.data = 3000;
     buf[2].type1.channel = CP_CH;   buf[2].type1.data = 0;
     buf[3].type1.channel = CP_CH;   buf[3].type1.data = 0;
-    g_dma_read_data = reinterpret_cast<uint8_t*>(buf);
-    g_dma_read_len = sizeof(buf);
+    adcMockSetDmaData(buf, 4);
 
     cpMonitorTestProcess();
 


### PR DESCRIPTION
## Summary
- drop analogReadMilliVolts stub from Arduino test utilities
- add DMA sample feeding mock for cp monitor
- update cp monitor tests to use DMA interface

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e59c9a4cc8324bf2891d72d79fadf