### PR TITLE
Include ADC stub in PlatformIO example

### DIFF
--- a/examples/platformio_complete/README.md
+++ b/examples/platformio_complete/README.md
@@ -17,6 +17,26 @@ The project pulls `libslac` automatically via `lib_deps`.
 Custom chip select and reset pins for the modem can be configured by
 editing `build_flags` in `platformio.ini`.
 
+### Required build flags
+
+`cp_monitor.cpp` uses the ESP-IDF continuous ADC API.  The Arduino core
+for ESP32-S3 does not currently ship this driver, so the example links a
+stub implementation from `../../port/esp_adc`.  Ensure the following
+lines are present in `platformio.ini` to compile and include the stub:
+
+```
+build_flags =
+    ...
+    -I../../port/esp_adc       ; ADC continuous driver headers
+
+build_src_filter =
+    +<src/*>
+    +<../../port/esp_adc/adc_continuous_stub.c>
+```
+
+These settings add `adc_continuous_stub.c` to the build and make the
+corresponding headers available.
+
 Defining `RANDOM_MAC` in `build_flags` or sending `R` over the serial
 console shortly after reset causes the example to generate a random
 locally administered MAC address.  The address is applied with

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -1,4 +1,7 @@
-[env:esp32-s3-devkitc-1]
+[platformio]
+src_dir = .
+
+[env:esp32s3]
 platform                    = espressif32
 board                       = esp32-s3-devkitc-1
 framework                   = arduino
@@ -17,11 +20,15 @@ build_flags =
     -DPLC_SPI_CS_PIN=36
     -DPLC_SPI_RST_PIN=40
     -DPLC_INT_PIN=16
+    -I../../port/esp_adc       ; ADC continuous driver headers
 
 
 ; remove the default -std=gnu++11 flag
 build_unflags = -std=gnu++11
 
+build_src_filter =
+    +<src/*>
+    +<../../port/esp_adc/adc_continuous_stub.c>
 extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =

--- a/port/esp_adc/adc_continuous_stub.c
+++ b/port/esp_adc/adc_continuous_stub.c
@@ -1,10 +1,32 @@
 #include "esp_adc/adc_continuous.h"
-int adc_continuous_new_handle(const adc_continuous_handle_cfg_t*, adc_continuous_handle_t* out) { if (out) *out = (void*)1; return 0; }
-int adc_continuous_config(adc_continuous_handle_t, const adc_continuous_config_t*) { return 0; }
-int adc_continuous_start(adc_continuous_handle_t) { return 0; }
-int adc_continuous_stop(adc_continuous_handle_t) { return 0; }
-int adc_continuous_deinit(adc_continuous_handle_t) { return 0; }
-int adc_continuous_read(adc_continuous_handle_t, uint8_t* buf, uint32_t len, uint32_t* outlen, int) {
-    if (outlen) *outlen = 0;
+
+int adc_continuous_new_handle(const adc_continuous_handle_cfg_t* cfg,
+                              adc_continuous_handle_t* out) {
+    if (out) {
+        *out = (void*)1;
+    }
+    return 0;
+}
+
+int adc_continuous_config(adc_continuous_handle_t handle,
+                          const adc_continuous_config_t* cfg) {
+    return 0;
+}
+
+int adc_continuous_start(adc_continuous_handle_t handle) { return 0; }
+
+int adc_continuous_stop(adc_continuous_handle_t handle) { return 0; }
+
+int adc_continuous_deinit(adc_continuous_handle_t handle) { return 0; }
+
+int adc_continuous_read(adc_continuous_handle_t handle, uint8_t* buf,
+                        uint32_t len, uint32_t* outlen, int timeout_ms) {
+    (void)handle;
+    (void)buf;
+    (void)len;
+    (void)timeout_ms;
+    if (outlen) {
+        *outlen = 0;
+    }
     return 0;
 }

--- a/port/esp_adc/esp_adc/adc_continuous.h
+++ b/port/esp_adc/esp_adc/adc_continuous.h
@@ -28,7 +28,10 @@ typedef struct {
 } adc_continuous_config_t;
 
 typedef struct {
-    struct { uint16_t data; } type1;
+    struct {
+        uint16_t data:12;
+        uint16_t channel:4;
+    } type1;
 } adc_digi_output_data_t;
 
 #define ADC_CONV_SINGLE_UNIT_1 0


### PR DESCRIPTION
## Summary
- document how to build the example with the ESP ADC stub
- ensure PlatformIO example includes the ADC stub

## Testing
- `pio run -e esp32s3`
- `cd examples/platformio_complete && pio run -e esp32s3`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688e60baef78832491b182e6c92875d7