### PR TITLE
Add CI workflow for esp32s3 build

### DIFF
--- a/.github/workflows/build-example.yml
+++ b/.github/workflows/build-example.yml
@@ -1,0 +1,30 @@
+name: Build example
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Cache PlatformIO
+        uses: actions/cache@v3
+        with:
+          path: ~/.platformio
+          key: ${{ runner.os }}-platformio-${{ hashFiles('**/platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-platformio-
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build
+        run: pio run -e esp32s3
+        env:
+          PLATFORMIO_BUILD_FLAGS: -Werror -Wno-error=attributes -Wno-error=address-of-packed-member


### PR DESCRIPTION
## Summary
- build esp32s3 example with PlatformIO on pushes and pull requests
- cache PlatformIO dependencies
- treat compiler warnings as errors (ignoring known framework warnings)

## Testing
- `./run_tests.sh`
- `PLATFORMIO_BUILD_FLAGS="-Werror -Wno-error=attributes -Wno-error=address-of-packed-member" pio run -e esp32s3`


------
https://chatgpt.com/codex/tasks/task_e_688e66be0a6c8324800a30a0bf81bc70