### PR TITLE
Refactor port timing helpers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -191,7 +191,7 @@ parameter.
        if (channel.poll(msg)) {
            // handle message
        }
-       delay(1);
+       slac_delay(1);
    }
 Polling Operation
 -----------------

--- a/docs/PlatformIOExample.md
+++ b/docs/PlatformIOExample.md
@@ -96,7 +96,7 @@ void loop() {
     if (g_channel && g_channel->poll(msg)) {
         // handle incoming packets
     }
-    delay(1);
+    slac_delay(1);
 }
 ```
 

--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -6,6 +6,11 @@
 #ifndef LIBSLAC_TESTING
 #include <freertos/task.h>
 #endif
+#ifdef ESP_PLATFORM
+#include <port/esp32s3/port_config.hpp>
+#else
+#include <port/port_common.hpp>
+#endif
 
 #ifndef ADC_ATTEN_DB_11
 #define ADC_ATTEN_DB_11 0
@@ -139,7 +144,7 @@ static void process_samples() {
     CpSubState cur = cp_state.load(std::memory_order_relaxed);
     if (stable_cnt >= 3 && ns != cur) {
         cp_state.store(ns, std::memory_order_relaxed);
-        cp_ts.store(millis(), std::memory_order_relaxed);
+        cp_ts.store(slac_millis(), std::memory_order_relaxed);
     }
 }
 
@@ -208,7 +213,7 @@ void cpMonitorInit() {
         cp_mv.store(mv, std::memory_order_relaxed);
         CpSubState ns = mv2state(mv);
         cp_state.store(ns, std::memory_order_relaxed);
-        cp_ts.store(millis(), std::memory_order_relaxed);
+        cp_ts.store(slac_millis(), std::memory_order_relaxed);
         last_raw = cp_vmax;
         stable_cnt = 1;
         if (vout_cnt > 0) {

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -72,7 +72,7 @@ static void handleInitialiseB1() {
             stageEnter(EVSE_IDLE_A);
             return;
         }
-        g_slac_ts.store(millis(), std::memory_order_relaxed);
+        g_slac_ts.store(slac_millis(), std::memory_order_relaxed);
         stageEnter(EVSE_DIGITAL_REQ_B2);
     }
 }

--- a/include/port/esp32s3/port_config.hpp
+++ b/include/port/esp32s3/port_config.hpp
@@ -1,7 +1,17 @@
 #ifndef SLAC_PORT_CONFIG_HPP
 #define SLAC_PORT_CONFIG_HPP
 
+#define slac_millis slac_millis
+#define slac_delay slac_delay
+#define slac_micros slac_micros
+#define slac_noInterrupts slac_noInterrupts
+#define slac_interrupts slac_interrupts
 #include "../port_common.hpp"
+#undef slac_millis
+#undef slac_delay
+#undef slac_micros
+#undef slac_noInterrupts
+#undef slac_interrupts
 
 #ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN   36

--- a/include/port/port_common.hpp
+++ b/include/port/port_common.hpp
@@ -3,38 +3,24 @@
 
 #include <stdint.h>
 
-#ifdef ARDUINO
-#include <Arduino.h>
-#endif
-
 #ifndef slac_millis
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline uint32_t slac_millis() { return millis(); }
-#endif
+inline __attribute__((weak)) uint32_t slac_millis() { return 0; }
 #endif
 
 #ifndef slac_delay
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_delay(uint32_t ms) { delay(ms); }
-#endif
+inline __attribute__((weak)) void slac_delay(uint32_t) {}
 #endif
 
 #ifndef slac_micros
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline uint32_t slac_micros() { return micros(); }
-#endif
+inline __attribute__((weak)) uint32_t slac_micros() { return 0; }
 #endif
 
 #ifndef slac_noInterrupts
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_noInterrupts() { noInterrupts(); }
-#endif
+inline __attribute__((weak)) void slac_noInterrupts() {}
 #endif
 
 #ifndef slac_interrupts
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_interrupts() { interrupts(); }
-#endif
+inline __attribute__((weak)) void slac_interrupts() {}
 #endif
 
 #endif // SLAC_GENERIC_PORT_CONFIG_HPP

--- a/port/esp32s3/port_config.hpp
+++ b/port/esp32s3/port_config.hpp
@@ -1,8 +1,17 @@
 #ifndef SLAC_PORT_CONFIG_HPP
 #define SLAC_PORT_CONFIG_HPP
 
+#define slac_millis slac_millis
+#define slac_delay slac_delay
+#define slac_micros slac_micros
+#define slac_noInterrupts slac_noInterrupts
+#define slac_interrupts slac_interrupts
 #include "../port_common.hpp"
-
+#undef slac_millis
+#undef slac_delay
+#undef slac_micros
+#undef slac_noInterrupts
+#undef slac_interrupts
 
 #ifndef PLC_SPI_CS_PIN
 #define PLC_SPI_CS_PIN   36
@@ -87,6 +96,9 @@ inline uint32_t htole32(uint32_t v) { return v; }
 #ifdef ESP_PLATFORM
 static inline uint32_t slac_millis() {
     return (uint32_t)(esp_timer_get_time() / 1000ULL);
+}
+static inline uint32_t slac_micros() {
+    return (uint32_t)esp_timer_get_time();
 }
 static inline void slac_delay(uint32_t ms) {
     vTaskDelay(pdMS_TO_TICKS(ms));

--- a/port/esp32s3/qca7000.cpp
+++ b/port/esp32s3/qca7000.cpp
@@ -1168,13 +1168,7 @@ uint8_t qca7000getSlacResult() {
     return g_slac_ctx.result;
 }
 
-static inline uint32_t get_us() {
-#ifdef ESP_PLATFORM
-    return (uint32_t)esp_timer_get_time();
-#else
-    return micros();
-#endif
-}
+static inline uint32_t get_us() { return slac_micros(); }
 
 static void process_cause(uint16_t cause) {
     if (cause & SPI_INT_CPU_ON) {

--- a/port/port_common.hpp
+++ b/port/port_common.hpp
@@ -3,32 +3,24 @@
 
 #include <stdint.h>
 
-#ifdef ARDUINO
-#include <Arduino.h>
-#endif
-
 #ifndef slac_millis
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline uint32_t slac_millis() { return millis(); }
-#endif
+inline __attribute__((weak)) uint32_t slac_millis() { return 0; }
 #endif
 
 #ifndef slac_delay
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_delay(uint32_t ms) { delay(ms); }
+inline __attribute__((weak)) void slac_delay(uint32_t) {}
 #endif
+
+#ifndef slac_micros
+inline __attribute__((weak)) uint32_t slac_micros() { return 0; }
 #endif
 
 #ifndef slac_noInterrupts
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_noInterrupts() { noInterrupts(); }
-#endif
+inline __attribute__((weak)) void slac_noInterrupts() {}
 #endif
 
 #ifndef slac_interrupts
-#if defined(ARDUINO) && !defined(ESP_PLATFORM)
-static inline void slac_interrupts() { interrupts(); }
-#endif
+inline __attribute__((weak)) void slac_interrupts() {}
 #endif
 
 #endif // SLAC_GENERIC_PORT_CONFIG_HPP

--- a/tests/time_mock.cpp
+++ b/tests/time_mock.cpp
@@ -1,11 +1,9 @@
 #include <cstdint>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+extern "C" uint32_t g_mock_millis = 0;
 
-uint32_t g_mock_millis = 0;
-
-#ifdef __cplusplus
-}
-#endif
+uint32_t slac_millis() { return g_mock_millis; }
+uint32_t slac_micros() { return g_mock_millis * 1000; }
+void slac_delay(uint32_t ms) { g_mock_millis += ms; }
+void slac_noInterrupts() {}
+void slac_interrupts() {}


### PR DESCRIPTION
## Summary
- provide weak slac_millis/slac_delay and related helpers
- implement ESP32-S3 timing helpers with ESP‑IDF APIs
- use slac_millis/slac_delay in examples and documentation

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ff3d21d88832493ce4e3489d094e9