### PR TITLE
Refactor ESP32-S3 port to ESP-IDF APIs

### DIFF
--- a/include/port/esp32s3/qca7000.hpp
+++ b/include/port/esp32s3/qca7000.hpp
@@ -4,9 +4,12 @@
 #include "port_config.hpp"
 
 #include "ethernet_defs.hpp"
-#ifdef ARDUINO
-#include <Arduino.h>
-#include <SPI.h>
+#ifdef ESP_PLATFORM
+#include "driver/gpio.h"
+#include "driver/spi_master.h"
+#else
+using spi_device_handle_t = void*;
+using gpio_num_t = int;
 #endif
 #include <slac/channel.hpp>
 #include <stddef.h>
@@ -69,13 +72,14 @@ static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length exceeds FIFO");
 
 
 struct qca7000_config {
-    SPIClass* spi;
+    spi_device_handle_t spi;
     int cs_pin;
     int rst_pin{PLC_SPI_RST_PIN};
     const uint8_t* mac_addr{nullptr};
 };
 
-bool qca7000setup(SPIClass* spi, int cs_pin, int rst_pin = PLC_SPI_RST_PIN);
+bool qca7000setup(spi_device_handle_t spi, int cs_pin,
+                  int rst_pin = PLC_SPI_RST_PIN);
 void qca7000teardown();
 bool qca7000ResetAndCheck();
 bool qca7000SoftReset();

--- a/include/port/esp32s3/qca7000_uart.hpp
+++ b/include/port/esp32s3/qca7000_uart.hpp
@@ -2,6 +2,9 @@
 
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
+#include "driver/uart.h"
+#else
+using uart_port_t = int;
 #endif
 
 #include "ethernet_defs.hpp"
@@ -13,12 +16,8 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
               "ETH_FRAME_LEN must not exceed V2GTP_BUFFER_SIZE");
 #include <slac/transport.hpp>
 
-#ifdef ARDUINO
-#include <HardwareSerial.h>
-#endif
-
 struct qca7000_uart_config {
-    HardwareSerial* serial;
+    uart_port_t uart_num;
     uint32_t baud;
     const uint8_t* mac_addr{nullptr};
 };

--- a/port/esp32s3/qca7000.hpp
+++ b/port/esp32s3/qca7000.hpp
@@ -4,9 +4,12 @@
 #include "port_config.hpp"
 
 #include "ethernet_defs.hpp"
-#ifdef ARDUINO
-#include <Arduino.h>
-#include <SPI.h>
+#ifdef ESP_PLATFORM
+#include "driver/gpio.h"
+#include "driver/spi_master.h"
+#else
+using spi_device_handle_t = void*;
+using gpio_num_t = int;
 #endif
 #include <slac/channel.hpp>
 #include <stddef.h>
@@ -69,13 +72,14 @@ static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length exceeds FIFO");
 
 
 struct qca7000_config {
-    SPIClass* spi;
+    spi_device_handle_t spi;
     int cs_pin;
     int rst_pin{PLC_SPI_RST_PIN};
     const uint8_t* mac_addr{nullptr};
 };
 
-bool qca7000setup(SPIClass* spi, int cs_pin, int rst_pin = PLC_SPI_RST_PIN);
+bool qca7000setup(spi_device_handle_t spi, int cs_pin,
+                  int rst_pin = PLC_SPI_RST_PIN);
 void qca7000teardown();
 bool qca7000ResetAndCheck();
 bool qca7000SoftReset();

--- a/port/esp32s3/qca7000_link.cpp
+++ b/port/esp32s3/qca7000_link.cpp
@@ -38,11 +38,11 @@ bool Qca7000Link::open() {
     if (initialization_error)
         return false;
 
-    SPIClass* bus = cfg.spi ? cfg.spi : &SPI;
+    spi_device_handle_t bus = cfg.spi;
     int cs = cfg.cs_pin ? cfg.cs_pin : PLC_SPI_CS_PIN;
     int rst = cfg.rst_pin ? cfg.rst_pin : PLC_SPI_RST_PIN;
 
-    if (ETH_FRAME_LEN > V2GTP_BUFFER_SIZE) {
+    if (ETH_FRAME_LEN > V2GTP_BUFFER_SIZE || !bus) {
         initialization_error = true;
         return false;
     }

--- a/port/esp32s3/qca7000_uart.hpp
+++ b/port/esp32s3/qca7000_uart.hpp
@@ -2,6 +2,9 @@
 
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
+#include "driver/uart.h"
+#else
+using uart_port_t = int;
 #endif
 
 #include "ethernet_defs.hpp"
@@ -13,12 +16,8 @@ static_assert(ETH_FRAME_LEN <= V2GTP_BUFFER_SIZE,
               "ETH_FRAME_LEN must not exceed V2GTP_BUFFER_SIZE");
 #include <slac/transport.hpp>
 
-#ifdef ARDUINO
-#include <HardwareSerial.h>
-#endif
-
 struct qca7000_uart_config {
-    HardwareSerial* serial;
+    uart_port_t uart_num;
     uint32_t baud;
     const uint8_t* mac_addr{nullptr};
 };

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -21,7 +21,7 @@ bool qca7000CheckBcbToggle();
 #undef htole32
 #endif
 
-SPIClass* spi_used = nullptr;
+spi_device_handle_t spi_used = nullptr;
 int spi_cs = -1;
 int spi_rst = -1;
 
@@ -72,7 +72,7 @@ extern "C" void mock_spi_feed_raw(const uint8_t* d, size_t l) {
     soft_reset_called = false;
 }
 
-bool qca7000setup(SPIClass* spi, int cs, int rst) {
+bool qca7000setup(spi_device_handle_t spi, int cs, int rst) {
     spi_used = spi; spi_cs = cs; spi_rst = rst; return true;
 }
 


### PR DESCRIPTION
## Summary
- migrate QCA7000 SPI handling to ESP-IDF `spi_device_handle_t` with bus acquisition and polling transactions
- switch GPIO control to `gpio_set_direction`/`gpio_set_level`
- move UART transport to ESP-IDF `uart_port_t` and driver install API

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_688ff7f7e9dc8324998fefe18c9c03e7