### PR TITLE
Port PlatformIO example to ESP-IDF

### DIFF
--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -2,18 +2,15 @@
 src_dir = .
 
 [env:esp32s3]
-platform                    = espressif32
+platform                    = espressif32@6.9.1
 board                       = esp32-s3-devkitc-1
-framework                   = arduino
+framework                   = espidf
 monitor_speed               = 115200
 monitor_filters             = esp32_exception_decoder
 board_build.partitions      = default_8MB.csv
 board_upload.flash_size     = 8MB
-board_build.arduino.memory_type = dio_qspi
 
 build_flags =
-    -DARDUINO_USB_MODE=1
-    -DARDUINO_USB_CDC_ON_BOOT=1
     -DAPP_CPU_FREQ_MHZ=240
     -std=gnu++17     ; use C++17
     -DESP_PLATFORM   ; compile for ESP platform
@@ -33,5 +30,4 @@ extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =
     ../../
-    SPI
 lib_ldf_mode = deep

--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -6,6 +6,7 @@
 #ifndef LIBSLAC_TESTING
 #include <freertos/task.h>
 #endif
+#include <esp_timer.h>
 #ifdef ESP_PLATFORM
 #include <port/esp32s3/port_config.hpp>
 #else
@@ -144,7 +145,8 @@ static void process_samples() {
     CpSubState cur = cp_state.load(std::memory_order_relaxed);
     if (stable_cnt >= 3 && ns != cur) {
         cp_state.store(ns, std::memory_order_relaxed);
-        cp_ts.store(slac_millis(), std::memory_order_relaxed);
+        cp_ts.store(static_cast<uint32_t>(esp_timer_get_time() / 1000),
+                    std::memory_order_relaxed);
     }
 }
 
@@ -213,7 +215,8 @@ void cpMonitorInit() {
         cp_mv.store(mv, std::memory_order_relaxed);
         CpSubState ns = mv2state(mv);
         cp_state.store(ns, std::memory_order_relaxed);
-        cp_ts.store(slac_millis(), std::memory_order_relaxed);
+        cp_ts.store(static_cast<uint32_t>(esp_timer_get_time() / 1000),
+                    std::memory_order_relaxed);
         last_raw = cp_vmax;
         stable_cnt = 1;
         if (vout_cnt > 0) {

--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include <stdint.h>
 #include "cp_config.h"
 
 enum CpSubState : uint8_t { CP_A, CP_B1, CP_B2, CP_B3, CP_C, CP_D, CP_E, CP_F };

--- a/examples/platformio_complete/src/cp_pwm.h
+++ b/examples/platformio_complete/src/cp_pwm.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include <stdint.h>
 #include "cp_config.h"
 
 void cpPwmInit();

--- a/examples/platformio_complete/src/cp_state_machine.h
+++ b/examples/platformio_complete/src/cp_state_machine.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <Arduino.h>
+#include <stdint.h>
 #include <atomic>
 #include <port/esp32s3/ethernet_defs.hpp>
 #include "cp_monitor.h"

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -1,9 +1,17 @@
-#include <Arduino.h>
 #include <slac/channel.hpp>
 #include <slac/slac.hpp>
 #include <port/esp32s3/qca7000_link.hpp>
 #include <port/esp32s3/qca7000.hpp>
+#include <port/esp32s3/port_config.hpp>
 #include <atomic>
+#include <cstdio>
+#include <esp_log.h>
+#include <esp_timer.h>
+#include <driver/gpio.h>
+#include <driver/uart.h>
+#include <driver/spi_master.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 #include "cp_pwm.h"
 #include "cp_monitor.h"
 #include "cp_state_machine.h"
@@ -16,9 +24,14 @@ extern void qca7000ProcessSlice(uint32_t max_us);
 // Default MAC address for the modem. Adjust as required.
 uint8_t g_mac_addr[ETH_ALEN] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
 bool g_use_random_mac = false;
+static const char* TAG = "MAIN";
 static const uint8_t EVSE_NMK[slac::defs::NMK_LEN] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F};
+
+static inline uint32_t get_ms() {
+    return static_cast<uint32_t>(esp_timer_get_time() / 1000);
+}
 
 // Global pointer used by the polling loop
 static slac::Channel* g_channel = nullptr;
@@ -31,13 +44,13 @@ std::atomic<uint32_t> g_slac_ts{0};
 static bool hlc_running = false;
 
 static void hlc_start() {
-    Serial.println("[HLC] start");
+    ESP_LOGI(TAG, "[HLC] start");
     hlc_running = true;
 }
 
 static void hlc_stop() {
     if (hlc_running) {
-        Serial.println("[HLC] stop");
+        ESP_LOGI(TAG, "[HLC] stop");
         hlc_running = false;
     }
 }
@@ -54,64 +67,86 @@ static void generate_random_mac() {
 }
 
 static void check_serial_flag() {
-    Serial.println("Press 'R' for random MAC");
-    uint32_t start = slac_millis();
-    while (slac_millis() - start < 3000) {
-        if (Serial.available()) {
-            char c = Serial.read();
-            if (c == 'R' || c == 'r')
+    printf("Press 'R' for random MAC\n");
+    int64_t start = esp_timer_get_time();
+    uint8_t data;
+    while ((esp_timer_get_time() - start) < 3000000) {
+        int len = uart_read_bytes(UART_NUM_0, &data, 1, 10 / portTICK_PERIOD_MS);
+        if (len > 0) {
+            if (data == 'R' || data == 'r')
                 g_use_random_mac = true;
             break;
         }
-        slac_delay(10);
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
     generate_random_mac();
 }
 
 static void logTask(void*) {
     const TickType_t period = pdMS_TO_TICKS(1000);
-    static char line[128];
     while (true) {
         uint32_t mv = cpGetVoltageMv();
-        int n = snprintf(line, sizeof(line),
-                         "[STAT] CP=%c %u.%03u V Stage=%s SLAC=%u\n",
-                         cpGetStateLetter(),
-                         mv / 1000, mv % 1000,
-                         evseStageName(evseGetStage()),
-                         g_slac_state.load(std::memory_order_relaxed));
-        Serial.write(line, n);
+        printf("[STAT] CP=%c %u.%03u V Stage=%s SLAC=%u\n",
+               cpGetStateLetter(),
+               mv / 1000, mv % 1000,
+               evseStageName(evseGetStage()),
+               g_slac_state.load(std::memory_order_relaxed));
         vTaskDelay(period);
     }
 }
 
-void setup() {
-    Serial.begin(115200);
-    slac_delay(4000);
-    Serial.println("Starting SLAC modem...");
+extern "C" void app_main(void) {
+    vTaskDelay(pdMS_TO_TICKS(4000));
+    ESP_LOGI(TAG, "Starting SLAC modem...");
     check_serial_flag();
-    pinMode(LOCK_FB_PIN, INPUT_PULLUP);
-    pinMode(CONTACTOR_FB_PIN, INPUT_PULLUP);
-    pinMode(ISOLATION_OK_PIN, INPUT_PULLUP);
 
-    SPI.begin(48 /*SCK*/, 21 /*MISO*/, 47 /*MOSI*/, -1);
-    Serial.println("Starting SPI");
-    qca7000_config cfg{&SPI, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, g_mac_addr};
-    Serial.println("Starting QCA7000 Link ");
+    gpio_config_t in_cfg{};
+    in_cfg.mode = GPIO_MODE_INPUT;
+    in_cfg.pull_up_en = GPIO_PULLUP_ENABLE;
+    in_cfg.pin_bit_mask = (1ULL << LOCK_FB_PIN) |
+                          (1ULL << CONTACTOR_FB_PIN) |
+                          (1ULL << ISOLATION_OK_PIN);
+    gpio_config(&in_cfg);
+
+    spi_bus_config_t buscfg{};
+    buscfg.mosi_io_num = PLC_SPI_MOSI_PIN;
+    buscfg.miso_io_num = PLC_SPI_MISO_PIN;
+    buscfg.sclk_io_num = PLC_SPI_SCK_PIN;
+    buscfg.max_transfer_sz = 1600;
+    ESP_ERROR_CHECK(spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO));
+
+    spi_device_interface_config_t devcfg{};
+    devcfg.clock_speed_hz = PLC_SPI_SLOW_HZ;
+    devcfg.mode = 3;
+    devcfg.spics_io_num = -1;
+    devcfg.queue_size = 3;
+    devcfg.flags = SPI_DEVICE_HALFDUPLEX;
+    spi_device_handle_t spi_handle;
+    ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &devcfg, &spi_handle));
+
+    qca7000_config cfg{spi_handle, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, g_mac_addr};
     static slac::port::Qca7000Link link(cfg);
     link.set_error_callback([](Qca7000ErrorStatus, void*) {
-        Serial.println("[PLC] Fatal error - driver auto-reset");
+        ESP_LOGI(TAG, "[PLC] Fatal error - driver auto-reset");
     }, nullptr);
     static slac::Channel channel(&link);
     g_channel = &channel;
-    Serial.println("Starting SLAC channel");
+    ESP_LOGI(TAG, "Starting SLAC channel");
     if (!channel.open()) {
-        Serial.println("Failed to open SLAC channel, aborting");
+        ESP_LOGE(TAG, "Failed to open SLAC channel, aborting");
         g_channel = nullptr;
         while (true)
-            slac_delay(1000);
+            vTaskDelay(pdMS_TO_TICKS(1000));
     }
-    pinMode(PLC_INT_PIN, INPUT);
-    attachInterrupt(PLC_INT_PIN, plc_isr, FALLING);
+
+    gpio_config_t int_cfg{};
+    int_cfg.pin_bit_mask = 1ULL << PLC_INT_PIN;
+    int_cfg.mode = GPIO_MODE_INPUT;
+    int_cfg.pull_up_en = GPIO_PULLUP_ENABLE;
+    int_cfg.intr_type = GPIO_INTR_NEGEDGE;
+    gpio_config(&int_cfg);
+    gpio_install_isr_service(0);
+    gpio_isr_handler_add(static_cast<gpio_num_t>(PLC_INT_PIN), plc_isr, nullptr);
     qca7000SetNmk(EVSE_NMK);
 
     cpPwmInit();
@@ -120,51 +155,48 @@ void setup() {
     xTaskCreatePinnedToCore(evseStateMachineTask, "evseSM", 4096, nullptr, 5, nullptr, 1);
     xTaskCreatePinnedToCore(logTask, "log", 4096, nullptr, 1, nullptr, 1);
 
-}
+    while (true) {
+        if (plc_irq) {
+            plc_irq = false;
+            qca7000ProcessSlice(500);
+        }
 
-void loop() {
-    if (plc_irq) {
-        plc_irq = false;
-        qca7000ProcessSlice(500);
-    }
+        slac::messages::HomeplugMessage msg;
+        if (g_channel && g_channel->poll(msg)) {
+            // Handle incoming SLAC messages here
+        }
 
-    slac::messages::HomeplugMessage msg;
-    if (g_channel && g_channel->poll(msg)) {
-        // Handle incoming SLAC messages here
-    }
-
-    // Detect PLC link loss only when digital comms are active
-    if (cpPwmIsRunning() &&
-        cpDigitalCommRequested() &&
-        !qca7000CheckAlive()) {
-        Serial.println("[PLC] link lost");
-        hlc_stop();
-        qca7000LeaveAvln();
-        if (g_use_random_mac)
-            qca7000SetMac(g_mac_addr);
-        if (qca7000startSlac())
-            g_slac_ts.store(slac_millis(), std::memory_order_relaxed);
-    }
-
-    // Update the SLAC state machine and restart if no progress for 60s
-    g_slac_state.store(qca7000getSlacResult(), std::memory_order_relaxed);
-    if (!hlc_running && g_slac_state.load(std::memory_order_relaxed) == 6)
-        hlc_start();
-    if (hlc_running && g_slac_state.load(std::memory_order_relaxed) != 6)
-        hlc_stop();
-    if (g_slac_state.load(std::memory_order_relaxed) != 0 &&
-        g_slac_state.load(std::memory_order_relaxed) != 5) {
-        if (slac_millis() - g_slac_ts.load(std::memory_order_relaxed) > 60000) {
-            Serial.println("Restarting SLAC handshake");
+        if (cpPwmIsRunning() &&
+            cpDigitalCommRequested() &&
+            !qca7000CheckAlive()) {
+            ESP_LOGI(TAG, "[PLC] link lost");
+            hlc_stop();
+            qca7000LeaveAvln();
             if (g_use_random_mac)
                 qca7000SetMac(g_mac_addr);
-            if (!qca7000startSlac())
-                Serial.println("startSlac failed");
-            g_slac_ts.store(slac_millis(), std::memory_order_relaxed);
+            if (qca7000startSlac())
+                g_slac_ts.store(get_ms(), std::memory_order_relaxed);
         }
-    } else {
-        g_slac_ts.store(slac_millis(), std::memory_order_relaxed);
-    }
 
-    slac_delay(1);
+        g_slac_state.store(qca7000getSlacResult(), std::memory_order_relaxed);
+        if (!hlc_running && g_slac_state.load(std::memory_order_relaxed) == 6)
+            hlc_start();
+        if (hlc_running && g_slac_state.load(std::memory_order_relaxed) != 6)
+            hlc_stop();
+        if (g_slac_state.load(std::memory_order_relaxed) != 0 &&
+            g_slac_state.load(std::memory_order_relaxed) != 5) {
+            if (get_ms() - g_slac_ts.load(std::memory_order_relaxed) > 60000) {
+                ESP_LOGI(TAG, "Restarting SLAC handshake");
+                if (g_use_random_mac)
+                    qca7000SetMac(g_mac_addr);
+                if (!qca7000startSlac())
+                    ESP_LOGI(TAG, "startSlac failed");
+                g_slac_ts.store(get_ms(), std::memory_order_relaxed);
+            }
+        } else {
+            g_slac_ts.store(get_ms(), std::memory_order_relaxed);
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(1));
+    }
 }


### PR DESCRIPTION
## Summary
- Replace Arduino framework with ESP-IDF in PlatformIO example configuration
- Refactor example to use `app_main` and ESP-IDF logging, timers, GPIO and LEDC APIs
- Remove Arduino headers from component interfaces

## Testing
- `pio run` *(fails: define_property command is not scriptable)*


------
https://chatgpt.com/codex/tasks/task_e_688ffbe47a2c83248fbc52840c588e7f