### PR TITLE
Make match_log portable

### DIFF
--- a/include/slac/match_log.hpp
+++ b/include/slac/match_log.hpp
@@ -1,8 +1,8 @@
 #ifndef SLAC_MATCH_LOG_HPP
 #define SLAC_MATCH_LOG_HPP
 
-#include <stdint.h>
 #include <slac/slac.hpp>
+#include <stdint.h>
 
 namespace slac {
 
@@ -24,6 +24,8 @@ match_log_fn_t get_match_log_fn();
 void slac_log_match(const MatchLogInfo& info);
 
 char slac_get_cp_state();
+
+extern const char* SLAC_LOG_TAG;
 
 } // namespace slac
 

--- a/src/match_log.cpp
+++ b/src/match_log.cpp
@@ -1,38 +1,41 @@
-#include <slac/match_log.hpp>
-#include <port/logging_compat.hpp>
-#include <port/esp32s3/qca7000.hpp>
 #include <cstdio>
+#include <slac/match_log.hpp>
 
 namespace slac {
 
 static match_log_fn_t g_log_fn = nullptr;
 
-void set_match_log_fn(match_log_fn_t fn) { g_log_fn = fn; }
-match_log_fn_t get_match_log_fn() { return g_log_fn; }
+__attribute__((weak)) const char* SLAC_LOG_TAG = "SLAC";
 
-__attribute__((weak)) char slac_get_cp_state() { return '?'; }
+void set_match_log_fn(match_log_fn_t fn) {
+    g_log_fn = fn;
+}
+match_log_fn_t get_match_log_fn() {
+    return g_log_fn;
+}
+
+__attribute__((weak)) char slac_get_cp_state() {
+    return '?';
+}
 
 #ifndef SLAC_DISABLE_MATCH_LOG
 static void default_log(const MatchLogInfo& info) {
     char pev[18];
-    snprintf(pev, sizeof(pev), "%02X:%02X:%02X:%02X:%02X:%02X",
-             info.pev_mac[0], info.pev_mac[1], info.pev_mac[2],
+    snprintf(pev, sizeof(pev), "%02X:%02X:%02X:%02X:%02X:%02X", info.pev_mac[0], info.pev_mac[1], info.pev_mac[2],
              info.pev_mac[3], info.pev_mac[4], info.pev_mac[5]);
     char evse[18];
-    snprintf(evse, sizeof(evse), "%02X:%02X:%02X:%02X:%02X:%02X",
-             info.evse_mac[0], info.evse_mac[1], info.evse_mac[2],
+    snprintf(evse, sizeof(evse), "%02X:%02X:%02X:%02X:%02X:%02X", info.evse_mac[0], info.evse_mac[1], info.evse_mac[2],
              info.evse_mac[3], info.evse_mac[4], info.evse_mac[5]);
     char nmk_hex[defs::NMK_LEN * 2 + 1];
     for (size_t i = 0; i < defs::NMK_LEN; ++i)
         sprintf(&nmk_hex[i * 2], "%02X", info.nmk[i]);
 
-    ESP_LOGI(PLC_TAG, "SLAC MATCH OK");
-    ESP_LOGI(PLC_TAG, "  PEV_MAC : %s", pev);
-    ESP_LOGI(PLC_TAG, "  EVSE_MAC: %s", evse);
-    ESP_LOGI(PLC_TAG, "  TONEMAP : min=%u avg=%u max=%u",
-             info.tone_min, info.tone_avg, info.tone_max);
-    ESP_LOGI(PLC_TAG, "  NMK     : %s", nmk_hex);
-    ESP_LOGI(PLC_TAG, "  CP_STATE: %c", info.cp_state);
+    printf("[%s] SLAC MATCH OK\n", SLAC_LOG_TAG);
+    printf("[%s]   PEV_MAC : %s\n", SLAC_LOG_TAG, pev);
+    printf("[%s]   EVSE_MAC: %s\n", SLAC_LOG_TAG, evse);
+    printf("[%s]   TONEMAP : min=%u avg=%u max=%u\n", SLAC_LOG_TAG, info.tone_min, info.tone_avg, info.tone_max);
+    printf("[%s]   NMK     : %s\n", SLAC_LOG_TAG, nmk_hex);
+    printf("[%s]   CP_STATE: %c\n", SLAC_LOG_TAG, info.cp_state);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- remove ESP-specific include and logging in match_log
- add weak log tag and printf-based default logging

## Testing
- `g++ -std=c++17 -Iinclude -c src/match_log.cpp`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68900ae0d5e083249db9bce9db980f07