### PR TITLE
chore: simplify PlatformIO config

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,38 +1,18 @@
 [platformio]
 src_dir = main
 
-
-[env:esp32s3]
-platform = espressif32@^6.9.1 ; use 64-bit GCC toolchain
-board = esp32-s3-devkitc-1  ; target board
-framework = espidf          ; build using the ESP-IDF
-
-platform_packages = toolchain-xtensa-esp32s3@~12.2.0
-
-# compilation flags
+[env]
 build_flags =
-    -std=gnu++17                 ; enable C++17
-    -Iinclude                    ; library headers
-    -I3rd_party                  ; third-party sources
-    -I3rd_party/fsm              ; FSM library
-    -Iport/esp32s3               ; board specific port
-    -DESP_PLATFORM               ; enable ESP platform features
-    -Os                          ; optimise for size
-    -fdata-sections              ; remove unused data
-    -ffunction-sections          ; remove unused functions
-    -fno-exceptions              ; disable exceptions
-    -DBUILD_SLAC_TOOLS=OFF       ; omit command line tools
-    -DBUILD_TESTING=OFF          ; disable library tests
-    -Wno-error=unused-value      ; suppress unused value warnings
-    -DPLC_SPI_CS_PIN=36
-    -DPLC_SPI_RST_PIN=40
-    -DPLC_SPI_SCK_PIN=48
-    -DPLC_SPI_MOSI_PIN=47
-    -DPLC_SPI_MISO_PIN=21
-    -DPLC_INT_PIN=16
-    -DQCA7000_HARDRESET_LOW_MS=20
-    -DQCA7000_HARDRESET_HIGH_MS=150
-    -DQCA7000_CPUON_TIMEOUT_MS=200
-    -Wl,-Map,firmware.map        ; optional linker map
+    -std=gnu++17
+    -Iinclude
+    -I3rd_party
+    -I3rd_party/fsm
+    -Os
+    -fdata-sections
+    -ffunction-sections
+    -fno-exceptions
+    -DBUILD_SLAC_TOOLS=OFF
+    -DBUILD_TESTING=OFF
+    -Wno-error=unused-value
 
 lib_ldf_mode = chain


### PR DESCRIPTION
## Summary
- remove hardware-specific build flags from root `platformio.ini`
- keep only generic options for packaging

## Testing
- `pio pkg pack --output libslac.tar.gz`

------
https://chatgpt.com/codex/tasks/task_e_68900fb24ac8832490627a854b2e94f0