### PR TITLE
Add portable htons helper

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
@@ -12,7 +12,7 @@
 #pragma pop_macro("ESP_LOGW")
 #undef RESTORE_ESP_LOGW
 #endif
-#include <arpa/inet.h>
+#include <slac/endian.hpp>
 #include <stdint.h>
 #ifndef ESP_PLATFORM
 static inline uint32_t esp_random() {
@@ -451,7 +451,7 @@ static bool read_region_code(qca7000_region* region) {
     memset(&req_msg, 0, sizeof(req_msg));
     memset(req_msg.eth.ether_dhost, 0xFF, ETH_ALEN);
     memcpy(req_msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    req_msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    req_msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     req_msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     req_msg.hp.mmtype =
         slac::htole16(slac::defs::qualcomm::MMTYPE_OP_ATTR |
@@ -470,7 +470,7 @@ static bool read_region_code(qca7000_region* region) {
         if (got < sizeof(ether_header) + 3)
             continue;
         const ether_header* eth = reinterpret_cast<const ether_header*>(buf);
-        if (eth->ether_type != htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY))
+        if (eth->ether_type != slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY))
             continue;
         const uint8_t* p = buf + sizeof(ether_header);
         uint8_t mmv = p[0];
@@ -678,7 +678,7 @@ static bool send_parm_req(const SlacContext& ctx) {
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_REQ);
     if (g_region == qca7000_region::NA)
@@ -704,7 +704,7 @@ static bool send_start_atten_char(const SlacContext& ctx) {
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_START_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND);
     msg.ind.application_type = slac::defs::COMMON_APPLICATION_TYPE;
@@ -730,7 +730,7 @@ static bool send_mnbc_sound(const SlacContext& ctx, uint8_t remaining) {
     memset(&msg, 0, sizeof(msg));
     memset(msg.eth.ether_dhost, 0xFF, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_MNBC_SOUND | slac::defs::MMTYPE_MODE_IND);
     msg.ind.application_type = slac::defs::COMMON_APPLICATION_TYPE;
@@ -757,7 +757,7 @@ static bool send_atten_char_rsp(const SlacContext& ctx, const uint8_t* dst,
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_RSP);
     msg.rsp.application_type = slac::defs::COMMON_APPLICATION_TYPE;
@@ -783,7 +783,7 @@ static bool send_atten_char_ind(const SlacContext& ctx) {
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, ctx.pev_mac, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype =
         slac::htole16(slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND);
@@ -815,7 +815,7 @@ static bool send_set_key_cnf(const SlacContext& ctx, const uint8_t* dst, const s
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_CNF);
     msg.cnf.result = slac::defs::CM_SET_KEY_CNF_RESULT_SUCCESS;
@@ -841,7 +841,7 @@ static bool send_validate_cnf(const uint8_t* dst, const slac::messages::cm_valid
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, dst, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_CNF);
     msg.cnf.signal_type = req->signal_type;
@@ -876,7 +876,7 @@ static bool send_match_cnf(const SlacContext& ctx) {
     memset(&msg, 0, sizeof(msg));
     memcpy(msg.eth.ether_dhost, ctx.match_src_mac, ETH_ALEN);
     memcpy(msg.eth.ether_shost, qca7000GetMac(), ETH_ALEN);
-    msg.eth.ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    msg.eth.ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     msg.hp.mmv = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     msg.hp.mmtype = slac::htole16(slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_CNF);
     msg.cnf.application_type = ctx.match_req.application_type;
@@ -1107,7 +1107,7 @@ uint8_t qca7000getSlacResult() {
         if (l < sizeof(ether_header) + 3)
             continue;
         const ether_header* eth = reinterpret_cast<const ether_header*>(d);
-        if (eth->ether_type != htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY))
+        if (eth->ether_type != slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY))
             continue;
         if (g_slac_ctx.filter_active &&
             memcmp(eth->ether_shost, g_slac_ctx.matched_mac, ETH_ALEN) != 0)

--- a/include/slac/endian.hpp
+++ b/include/slac/endian.hpp
@@ -15,6 +15,10 @@
 #undef htole64
 #undef le64toh
 #endif
+#ifdef htons
+#undef htons
+#undef ntohs
+#endif
 
 #ifndef __LITTLE_ENDIAN
 #define __LITTLE_ENDIAN 1234
@@ -83,6 +87,17 @@ inline constexpr uint64_t htole64(uint64_t v) {
 #endif
 }
 inline constexpr uint64_t le64toh(uint64_t v) { return htole64(v); }
+#endif
+
+#if !defined(ESP_PLATFORM) && !defined(htons)
+inline constexpr uint16_t htons(uint16_t v) {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    return bswap16(v);
+#else
+    return v;
+#endif
+}
+inline constexpr uint16_t ntohs(uint16_t v) { return htons(v); }
 #endif
 
 } // namespace slac

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -10,7 +10,6 @@
 #include <cstring>
 #include <type_traits>
 
-#include <arpa/inet.h>
 #include <slac/endian.hpp>
 
 #include <hash_library/sha256.h>
@@ -125,7 +124,7 @@ void HomeplugMessage::setup_ethernet_header(const uint8_t dst_mac_addr[ETH_ALEN]
                                             const uint8_t src_mac_addr[ETH_ALEN]) {
 
     // ethernet frame byte order is big endian
-    raw_msg.ethernet_header.ether_type = htons(defs::ETH_P_HOMEPLUG_GREENPHY);
+    raw_msg.ethernet_header.ether_type = slac::htons(defs::ETH_P_HOMEPLUG_GREENPHY);
     if (dst_mac_addr) {
         memcpy(raw_msg.ethernet_header.ether_dhost, dst_mac_addr, ETH_ALEN);
     }

--- a/tests/test_endian.cpp
+++ b/tests/test_endian.cpp
@@ -18,3 +18,14 @@ TEST(Endian, HostLE) {
     EXPECT_EQ(slac::htole64(v64), v64);
     EXPECT_EQ(slac::le64toh(v64), v64);
 }
+
+TEST(Endian, Network) {
+    uint16_t v16 = 0xA1B2u;
+    uint16_t net = slac::htons(v16);
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+    EXPECT_EQ(net, 0xB2A1u);
+#else
+    EXPECT_EQ(net, v16);
+#endif
+    EXPECT_EQ(slac::ntohs(net), v16);
+}

--- a/tests/test_slac_filter.cpp
+++ b/tests/test_slac_filter.cpp
@@ -4,7 +4,7 @@
 #include "port/esp32s3/qca7000.hpp"
 #include <slac/slac.hpp>
 #include <slac/config.hpp>
-#include <arpa/inet.h>
+#include <slac/endian.hpp>
 
 extern "C" void mock_receive_frame(const uint8_t*, size_t);
 extern "C" void mock_ring_reset();
@@ -13,7 +13,7 @@ static void send_frame(uint16_t mmtype, const uint8_t src[ETH_ALEN]) {
     uint8_t frame[sizeof(ether_header) + 3]{};
     ether_header* eth = reinterpret_cast<ether_header*>(frame);
     memcpy(eth->ether_shost, src, ETH_ALEN);
-    eth->ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    eth->ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     frame[sizeof(ether_header)] = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     uint16_t t = slac::htole16(mmtype);
     memcpy(frame + sizeof(ether_header) + 1, &t, 2);

--- a/tests/test_validation.cpp
+++ b/tests/test_validation.cpp
@@ -4,7 +4,7 @@
 #include "port/esp32s3/qca7000.hpp"
 #include <slac/slac.hpp>
 #include <slac/config.hpp>
-#include <arpa/inet.h>
+#include <slac/endian.hpp>
 
 extern "C" void mock_receive_frame(const uint8_t*, size_t);
 extern "C" void mock_ring_reset();
@@ -14,7 +14,7 @@ static void send_frame(uint16_t mmtype, const uint8_t src[ETH_ALEN]) {
     uint8_t frame[sizeof(ether_header) + 3]{};
     ether_header* eth = reinterpret_cast<ether_header*>(frame);
     memcpy(eth->ether_shost, src, ETH_ALEN);
-    eth->ether_type = htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
+    eth->ether_type = slac::htons(slac::defs::ETH_P_HOMEPLUG_GREENPHY);
     frame[sizeof(ether_header)] = static_cast<uint8_t>(slac::defs::MMV::AV_1_0);
     uint16_t t = slac::htole16(mmtype);
     memcpy(frame + sizeof(ether_header) + 1, &t, 2);


### PR DESCRIPTION
## Summary
- implement slac::htons/ntohs using byte-swap helpers
- drop `<arpa/inet.h>` in favor of portable endian header
- adjust sources and tests to use new API

## Testing
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_689011bb80808324903cef515c9dd595