### PR TITLE
refactor: isolate hardware-specific code and update example

### DIFF
--- a/3rd_party/hash_library/sha256.cpp
+++ b/3rd_party/hash_library/sha256.cpp
@@ -6,7 +6,6 @@
 // see http://create.stephan-brumme.com/disclaimer.html
 //
 
-#include "port/port_common.hpp"
 #include "sha256.h"
 #include <cstring>
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,12 @@
+# When this repository is included as an ESP-IDF component the build
+# system first parses this file in "script mode" which only allows a
+# limited set of commands.  Avoid running the normal project setup in
+# that case to prevent errors such as "define_property command is not
+# scriptable".
+if(CMAKE_SCRIPT_MODE_FILE)
+    return()
+endif()
+
 cmake_minimum_required(VERSION 3.16.0)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(libslac)

--- a/examples/platformio_complete/CMakeLists.txt
+++ b/examples/platformio_complete/CMakeLists.txt
@@ -1,0 +1,10 @@
+# Guard against the ESP-IDF "script mode" pass which executes this
+# file with a reduced set of commands.  Only proceed with the full
+# project setup during the normal configure step.
+if(CMAKE_SCRIPT_MODE_FILE)
+    return()
+endif()
+
+cmake_minimum_required(VERSION 3.16.0)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(platformio_complete)

--- a/examples/platformio_complete/lib/libcbv2g/CMakeLists.txt
+++ b/examples/platformio_complete/lib/libcbv2g/CMakeLists.txt
@@ -1,10 +1,17 @@
+if(CMAKE_SCRIPT_MODE_FILE)
+    # Prevent ESP-IDF's script-mode pass from executing the third-party
+    # library's full build logic. The actual build is performed in the
+    # PlatformIO pre-build step.
+    return()
+endif()
+
 cmake_minimum_required(VERSION 3.14)
 
 project(cb_v2g
     VERSION 0.3.1
     DESCRIPTION "V2GTP EXI library"
     HOMEPAGE_URL "https://github.com/Everest/libcbv2g"
-	LANGUAGES C CXX
+    LANGUAGES C CXX
 )
 
 find_package(everest-cmake 0.1 REQUIRED

--- a/examples/platformio_complete/lib/slac_port/esp32s3/port_config.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/port_config.hpp
@@ -78,21 +78,6 @@ static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
 #endif
 static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
 
-namespace slac {
-#ifndef le16toh
-inline uint16_t le16toh(uint16_t v) { return v; }
-#endif
-#ifndef htole16
-inline uint16_t htole16(uint16_t v) { return v; }
-#endif
-#ifndef le32toh
-inline uint32_t le32toh(uint32_t v) { return v; }
-#endif
-#ifndef htole32
-inline uint32_t htole32(uint32_t v) { return v; }
-#endif
-} // namespace slac
-
 #ifdef ESP_PLATFORM
 static inline uint32_t slac_millis() {
     return (uint32_t)(esp_timer_get_time() / 1000ULL);

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
@@ -1,6 +1,4 @@
 #include "qca7000.hpp"
-#include <port/port_common.hpp>
-#include <esp32s3/port_config.hpp>
 #include <slac/config.hpp>
 #ifdef ESP_LOGW
 #pragma push_macro("ESP_LOGW")

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <port/port_common.hpp>
 #include "port_config.hpp"
 
 #include <slac/ethernet_defs.hpp>

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
@@ -1,7 +1,4 @@
 #include "qca7000_link.hpp"
-#include <port/port_common.hpp>
-#include "port_config.hpp"
-#include "qca7000.hpp"
 #include <cstring>
 
 namespace slac {
@@ -10,7 +7,7 @@ namespace port {
 Qca7000Link::Qca7000Link(const qca7000_config& c,
                          ErrorCallback cb,
                          void* cb_arg)
-    : cfg(c), error_cb(cb), error_arg(cb_arg) {
+    : error_cb(cb), error_arg(cb_arg), cfg(c) {
     memset(mac_addr, 0, sizeof(mac_addr));
     if (cfg.mac_addr)
         memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.hpp
@@ -1,7 +1,6 @@
 #ifndef SLAC_QCA7000_LINK_HPP
 #define SLAC_QCA7000_LINK_HPP
 
-#include <port/port_common.hpp>
 #ifdef ESP_PLATFORM
 #include "port_config.hpp"
 #endif

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -1,13 +1,12 @@
 [platformio]
-src_dir = .
+src_dir = src
 
 [env:esp32s3]
-platform                    = espressif32@6.9.1
+platform                    = espressif32@6.8.1
 board                       = esp32-s3-devkitc-1
 framework                   = espidf
 monitor_speed               = 115200
 monitor_filters             = esp32_exception_decoder
-board_build.partitions      = default_8MB.csv
 board_upload.flash_size     = 8MB
 
 build_flags =
@@ -18,7 +17,6 @@ build_flags =
     -DPLC_SPI_RST_PIN=40
     -DPLC_INT_PIN=16
     -Ilib/slac_port
-    -Ilib/slac_port/esp_adc    ; ADC continuous driver headers
 
 
 ; remove the default -std=gnu++11 flag
@@ -26,8 +24,10 @@ build_unflags = -std=gnu++11
 
 build_src_filter =
     +<src/*>
+    +<../lib/slac_port/esp32s3/*.cpp>
 extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =
     ../../
 lib_ldf_mode = deep
+lib_ignore = libcbv2g

--- a/examples/platformio_complete/src/cp_config.h
+++ b/examples/platformio_complete/src/cp_config.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <stdint.h>
+#ifdef ESP_PLATFORM
+#include <freertos/FreeRTOS.h>
+#endif
 
 #define CP_PWM_OUT_PIN      38
 #define CP_READ_ADC_PIN     1

--- a/examples/platformio_complete/src/cp_monitor.cpp
+++ b/examples/platformio_complete/src/cp_monitor.cpp
@@ -123,11 +123,11 @@ static void process_samples() {
     uint16_t vout_cnt = 0;
     for (size_t i = 0; i < n; ++i) {
         auto* d = reinterpret_cast<adc_digi_output_data_t*>(buf + i * sizeof(adc_digi_output_data_t));
-        uint16_t raw = d->type1.data;
-        if (d->type1.channel == CP_ADC_CHANNEL) {
+        uint16_t raw = d->type2.data;
+        if (d->type2.channel == CP_ADC_CHANNEL) {
             if (raw > cp_vmax)
                 cp_vmax = raw;
-        } else if (d->type1.channel == VOUT_ADC_CHANNEL) {
+        } else if (d->type2.channel == VOUT_ADC_CHANNEL) {
             vout_sum += raw;
             ++vout_cnt;
         }
@@ -208,11 +208,11 @@ void cpMonitorInit() {
         uint16_t vout_cnt = 0;
         for (size_t i = 0; i < n; ++i) {
             auto* d = reinterpret_cast<adc_digi_output_data_t*>(buf + i * sizeof(adc_digi_output_data_t));
-            uint16_t raw = d->type1.data;
-            if (d->type1.channel == CP_ADC_CHANNEL) {
+            uint16_t raw = d->type2.data;
+            if (d->type2.channel == CP_ADC_CHANNEL) {
                 if (raw > cp_vmax)
                     cp_vmax = raw;
-            } else if (d->type1.channel == VOUT_ADC_CHANNEL) {
+            } else if (d->type2.channel == VOUT_ADC_CHANNEL) {
                 vout_sum += raw;
                 ++vout_cnt;
             }

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -5,6 +5,7 @@
 #include <esp32s3/qca7000.hpp>
 #include <esp_log.h>
 #include <esp_timer.h>
+#include <esp_random.h>
 #include <driver/gpio.h>
 
 extern bool g_use_random_mac;

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -8,6 +8,8 @@
 #include <cstdio>
 #include <esp_log.h>
 #include <esp_timer.h>
+#include <esp_system.h>
+#include <esp_random.h>
 #include <driver/gpio.h>
 #include <driver/uart.h>
 #include <driver/spi_master.h>
@@ -39,7 +41,7 @@ static slac::Channel* g_channel = nullptr;
 volatile bool plc_irq = false;
 std::atomic<uint8_t> g_slac_state{0};
 
-void IRAM_ATTR plc_isr() { plc_irq = true; }
+void IRAM_ATTR plc_isr(void*) { plc_irq = true; }
 // Timestamp for SLAC restart logic
 std::atomic<uint32_t> g_slac_ts{0};
 static bool hlc_running = false;
@@ -87,9 +89,10 @@ static void logTask(void*) {
     const TickType_t period = pdMS_TO_TICKS(1000);
     while (true) {
         uint32_t mv = cpGetVoltageMv();
-        printf("[STAT] CP=%c %u.%03u V Stage=%s SLAC=%u\n",
+        printf("[STAT] CP=%c %lu.%03lu V Stage=%s SLAC=%u\n",
                cpGetStateLetter(),
-               mv / 1000, mv % 1000,
+               static_cast<unsigned long>(mv / 1000),
+               static_cast<unsigned long>(mv % 1000),
                evseStageName(evseGetStage()),
                g_slac_state.load(std::memory_order_relaxed));
         vTaskDelay(period);

--- a/include/slac/channel.hpp
+++ b/include/slac/channel.hpp
@@ -3,8 +3,6 @@
 #ifndef SLAC_CHANNEL_HPP
 #define SLAC_CHANNEL_HPP
 
-#include "port/port_common.hpp"
-
 #include <slac/transport.hpp>
 #include <string>
 

--- a/include/slac/endian.hpp
+++ b/include/slac/endian.hpp
@@ -55,7 +55,7 @@ static inline constexpr uint64_t bswap64(uint64_t v) {
 }
 
 
-#if !defined(ESP_PLATFORM) && !defined(htole16)
+#if !defined(htole16)
 inline constexpr uint16_t htole16(uint16_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -67,7 +67,7 @@ inline constexpr uint16_t le16toh(uint16_t v) { return htole16(v); }
 #endif
 
 
-#if !defined(ESP_PLATFORM) && !defined(htole32)
+#if !defined(htole32)
 inline constexpr uint32_t htole32(uint32_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -78,7 +78,7 @@ inline constexpr uint32_t htole32(uint32_t v) {
 inline constexpr uint32_t le32toh(uint32_t v) { return htole32(v); }
 #endif
 
-#if !defined(ESP_PLATFORM) && !defined(htole64)
+#if !defined(htole64)
 inline constexpr uint64_t htole64(uint64_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -89,7 +89,7 @@ inline constexpr uint64_t htole64(uint64_t v) {
 inline constexpr uint64_t le64toh(uint64_t v) { return htole64(v); }
 #endif
 
-#if !defined(ESP_PLATFORM) && !defined(htons)
+#if !defined(htons)
 inline constexpr uint16_t htons(uint16_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return bswap16(v);

--- a/include/slac/slac.hpp
+++ b/include/slac/slac.hpp
@@ -3,8 +3,6 @@
 #ifndef SLAC_SLAC_HPP
 #define SLAC_SLAC_HPP
 
-#include "port/port_common.hpp"
-
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>

--- a/include/slac/transport.hpp
+++ b/include/slac/transport.hpp
@@ -1,8 +1,6 @@
 #ifndef SLAC_TRANSPORT_HPP
 #define SLAC_TRANSPORT_HPP
 
-#include "port/port_common.hpp"
-
 #include <cstddef>
 #include <cstdint>
 

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -14,8 +14,8 @@ if [ ! -f /usr/include/gtest/gtest.h ] && [ ! -f /usr/local/include/gtest/gtest.
     fi
 fi
 
-CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -DportTICK_PERIOD_MS=1 -Iinclude -I3rd_party -I3rd_party/fsm -Iport/esp32s3 -Iport -Itests -Iexamples/platformio_complete/src -I. -Wduplicated-cond -Wduplicated-branches"
-SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/test_qca7000_fetch_rx.cpp tests/test_cp_monitor.cpp tests/cp_monitor_mocks.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp examples/platformio_complete/src/cp_monitor.cpp port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
+CXXFLAGS="-std=c++17 -DNDEBUG -DLIBSLAC_TESTING -DARDUINO -DportTICK_PERIOD_MS=1 -Iinclude -I3rd_party -I3rd_party/fsm -Iexamples/platformio_complete/lib/slac_port -Iexamples/platformio_complete/lib/slac_port/esp32s3 -Itests -Iexamples/platformio_complete/src -I. -Wduplicated-cond -Wduplicated-branches"
+SRCS="tests/test_endian.cpp tests/test_sha256.cpp tests/test_nid.cpp tests/test_payload.cpp tests/test_channel.cpp tests/test_fsm.cpp tests/test_fsm_buffer.cpp tests/test_qca7000_link.cpp tests/test_reset.cpp tests/test_check_alive.cpp tests/test_rx_ring.cpp tests/test_slac_retry.cpp tests/test_bcb_wakeup.cpp tests/test_slac_filter.cpp tests/test_validation.cpp tests/test_qca7000_fetch_rx.cpp tests/test_cp_monitor.cpp tests/cp_monitor_mocks.cpp tests/time_mock.cpp tests/qca7000_hal_mock.cpp src/channel.cpp src/slac.cpp src/config.cpp src/match_log.cpp examples/platformio_complete/src/cp_monitor.cpp examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp 3rd_party/hash_library/sha256.cpp"
 
 
 #g++ $CXXFLAGS $SRCS -lgtest -lgtest_main -pthread -o tests_run

--- a/src/channel.cpp
+++ b/src/channel.cpp
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Joulepoint Private Limited (Author Chinmoy Bhuyan)
 #include <slac/channel.hpp>
-#ifdef ESP_PLATFORM
-#include "port/port_common.hpp"
-#endif
 
 #include <algorithm>
 #include <cassert>

--- a/src/slac.cpp
+++ b/src/slac.cpp
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2024 Joulepoint Private Limited (Author Chinmoy Bhuyan)
 #include <slac/slac.hpp>
-#ifdef ESP_PLATFORM
-#include "port/port_common.hpp"
-#endif
 
 #include <algorithm>
 #include <cassert>

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -1,5 +1,5 @@
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 #include <slac/iso15118_consts.hpp>
 #include <slac/config.hpp>
 #include <cstdint>

--- a/tests/test_bcb_wakeup.cpp
+++ b/tests/test_bcb_wakeup.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 extern bool mock_bcb_toggle;
 extern bool wake_called;

--- a/tests/test_check_alive.cpp
+++ b/tests/test_check_alive.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 extern uint16_t mock_signature;
 extern uint16_t mock_wrbuf;

--- a/tests/test_qca7000_fetch_rx.cpp
+++ b/tests/test_qca7000_fetch_rx.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 extern "C" void mock_ring_reset();
 extern "C" void mock_spi_feed_raw(const uint8_t*, size_t);

--- a/tests/test_qca7000_link.cpp
+++ b/tests/test_qca7000_link.cpp
@@ -1,8 +1,8 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000_link.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000_link.hpp"
+#include "qca7000.hpp"
 
 extern "C" void mock_receive_frame(const uint8_t*, size_t);
 

--- a/tests/test_qca7000_reset.cpp
+++ b/tests/test_qca7000_reset.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 extern bool reset_called;
 

--- a/tests/test_reset.cpp
+++ b/tests/test_reset.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 TEST(Qca7000ResetSimple, ReturnsTrue) {
     ASSERT_TRUE(qca7000ResetAndCheck());

--- a/tests/test_rx_ring.cpp
+++ b/tests/test_rx_ring.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 
 extern "C" void mock_ring_reset();
 extern "C" void mock_receive_frame(const uint8_t*, size_t);

--- a/tests/test_slac_filter.cpp
+++ b/tests/test_slac_filter.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 #include <slac/slac.hpp>
 #include <slac/config.hpp>
 #include <slac/endian.hpp>

--- a/tests/test_slac_retry.cpp
+++ b/tests/test_slac_retry.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 #include <slac/iso15118_consts.hpp>
 
 extern uint32_t g_mock_millis;

--- a/tests/test_validation.cpp
+++ b/tests/test_validation.cpp
@@ -1,7 +1,7 @@
 #include <gtest/gtest.h>
 #define ARDUINO
 #include "arduino_stubs.hpp"
-#include "port/esp32s3/qca7000.hpp"
+#include "qca7000.hpp"
 #include <slac/slac.hpp>
 #include <slac/config.hpp>
 #include <slac/endian.hpp>


### PR DESCRIPTION
## Summary
- guard CMake project files to handle ESP-IDF's script mode pass
- ignore third-party cbv2g during IDF configure and clean up PlatformIO config
- provide endian helpers on all platforms

## Testing
- `./run_tests.sh`
- `platformio run` *(fails: undefined references for Qca7000 port symbols)*

------
https://chatgpt.com/codex/tasks/task_e_689014506eec8324853d72e32db82454