### PR TITLE
Fix PlatformIO example build

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/port_config.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/port_config.hpp
@@ -79,18 +79,6 @@ static_assert(PLC_SPI_RST_PIN >= 0, "RST pin unset");
 static_assert(QCA7000_SPI_BURST_LEN <= 512, "Burst length too large");
 
 namespace slac {
-#ifndef le16toh
-inline uint16_t le16toh(uint16_t v) { return v; }
-#endif
-#ifndef htole16
-inline uint16_t htole16(uint16_t v) { return v; }
-#endif
-#ifndef le32toh
-inline uint32_t le32toh(uint32_t v) { return v; }
-#endif
-#ifndef htole32
-inline uint32_t htole32(uint32_t v) { return v; }
-#endif
 } // namespace slac
 
 #ifdef ESP_PLATFORM

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
@@ -10,7 +10,7 @@ namespace port {
 Qca7000Link::Qca7000Link(const qca7000_config& c,
                          ErrorCallback cb,
                          void* cb_arg)
-    : cfg(c), error_cb(cb), error_arg(cb_arg) {
+    : error_cb(cb), error_arg(cb_arg), cfg(c) {
     memset(mac_addr, 0, sizeof(mac_addr));
     if (cfg.mac_addr)
         memcpy(mac_addr, cfg.mac_addr, ETH_ALEN);

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_uart.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_uart.hpp
@@ -5,6 +5,7 @@
 #include "driver/uart.h"
 #else
 using uart_port_t = int;
+static constexpr uart_port_t UART_NUM_MAX = -1;
 #endif
 
 #include <slac/ethernet_defs.hpp>

--- a/include/slac/endian.hpp
+++ b/include/slac/endian.hpp
@@ -55,7 +55,7 @@ static inline constexpr uint64_t bswap64(uint64_t v) {
 }
 
 
-#if !defined(ESP_PLATFORM) && !defined(htole16)
+#ifndef htole16
 inline constexpr uint16_t htole16(uint16_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -67,7 +67,7 @@ inline constexpr uint16_t le16toh(uint16_t v) { return htole16(v); }
 #endif
 
 
-#if !defined(ESP_PLATFORM) && !defined(htole32)
+#ifndef htole32
 inline constexpr uint32_t htole32(uint32_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -78,7 +78,7 @@ inline constexpr uint32_t htole32(uint32_t v) {
 inline constexpr uint32_t le32toh(uint32_t v) { return htole32(v); }
 #endif
 
-#if !defined(ESP_PLATFORM) && !defined(htole64)
+#ifndef htole64
 inline constexpr uint64_t htole64(uint64_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return v;
@@ -89,7 +89,7 @@ inline constexpr uint64_t htole64(uint64_t v) {
 inline constexpr uint64_t le64toh(uint64_t v) { return htole64(v); }
 #endif
 
-#if !defined(ESP_PLATFORM) && !defined(htons)
+#ifndef htons
 inline constexpr uint16_t htons(uint16_t v) {
 #if __BYTE_ORDER == __LITTLE_ENDIAN
     return bswap16(v);


### PR DESCRIPTION
## Summary
- make endian helpers available on all platforms
- update QCA7000 example drivers for ESP-IDF 5
- clean up PlatformIO example UART utilities

## Testing
- `pio run -d examples/platformio_complete`

------
https://chatgpt.com/codex/tasks/task_e_68901df8349083248a7d08c07596afd7