### PR TITLE
Fix test to include endian header

### DIFF
--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -2,6 +2,7 @@
 #include "qca7000.hpp"
 #include <slac/iso15118_consts.hpp>
 #include <slac/config.hpp>
+#include <slac/endian.hpp>
 #include <cstdint>
 #include <atomic>
 extern uint32_t g_mock_millis;


### PR DESCRIPTION
## Summary
- include endian utilities in qca7000 HAL mock test to compile

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6890227e20ec832491a1efb414aa6ff6