### PR TITLE
Document QCA7005 compatibility and fix tests

### DIFF
--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -3,7 +3,9 @@
 This example demonstrates how to wire the QCA7000 modem to an
 ESP32-S3 board using PlatformIO. The board uses custom SPI pins and
 it is recommended to connect the interrupt line (`PLC_INT_PIN`, IO16 by
-default) so the driver can react to modem events.
+default) so the driver can react to modem events. QCA7005-based PLC
+Stamp micro modules are fully compatible and can be wired in the same
+way.
 
 ## PlatformIO configuration
 

--- a/docs/PlatformIOExample.md
+++ b/docs/PlatformIOExample.md
@@ -3,7 +3,9 @@
 This guide walks through creating a minimal PlatformIO project that uses
 `libslac` with an ESP32 board running the Arduino framework.  It
 communicates with a QCA7000 based power line modem and explains the
-required steps in a short tutorial.
+required steps in a short tutorial. The code is equally compatible with
+the QCA7005 variant used on PLC Stamp micro modules, which are pin and
+software compatible with QCA7000 devices.
 
 ## 1. Install PlatformIO
 

--- a/examples/platformio_complete/README.md
+++ b/examples/platformio_complete/README.md
@@ -3,7 +3,8 @@
 This directory contains a fully self-contained PlatformIO project
 showing how to use **libslac** on an ESP32-S3 board.  The example
 initialises a QCA7000 modem, polls it for incoming SLAC frames and can
-be built directly with PlatformIO.
+be built directly with PlatformIO.  QCA7005-based PLC Stamp micro
+modules operate the same way and can be used without code changes.
 
 ## Building
 

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -2,6 +2,7 @@
 #include "qca7000.hpp"
 #include <slac/iso15118_consts.hpp>
 #include <slac/config.hpp>
+#include <slac/endian.hpp>
 #include <cstdint>
 #include <atomic>
 extern uint32_t g_mock_millis;


### PR DESCRIPTION
## Summary
- mention QCA7005/PLC Stamp micro compatibility in documentation and example
- ensure qca7000 HAL mock includes endian helpers so unit tests build

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6890227e20ec832491a1efb414aa6ff6