### PR TITLE
Detect missing CPU_ON during QCA7000 resets

### DIFF
--- a/tests/test_check_alive.cpp
+++ b/tests/test_check_alive.cpp
@@ -26,4 +26,5 @@ TEST(Qca7000CheckAlive, CpuOff) {
     mock_wrbuf = 0x0C5B;
     mock_intr_cause = 0;
     EXPECT_FALSE(qca7000CheckAlive());
+    mock_intr_cause = SPI_INT_CPU_ON;
 }

--- a/tests/test_qca7000_reset.cpp
+++ b/tests/test_qca7000_reset.cpp
@@ -4,9 +4,15 @@
 #include "qca7000.hpp"
 
 extern bool reset_called;
+extern uint16_t mock_signature;
+extern uint16_t mock_wrbuf;
+extern uint16_t mock_intr_cause;
 
 TEST(Qca7000Hal, ResetAndCheck) {
     reset_called = false;
+    mock_signature = 0xAA55;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = SPI_INT_CPU_ON;
     ASSERT_TRUE(qca7000ResetAndCheck());
     EXPECT_TRUE(reset_called);
 }

--- a/tests/test_reset.cpp
+++ b/tests/test_reset.cpp
@@ -2,7 +2,35 @@
 #define ARDUINO
 #include "arduino_stubs.hpp"
 #include "qca7000.hpp"
+#include <string>
+
+extern uint16_t mock_signature;
+extern uint16_t mock_wrbuf;
+extern uint16_t mock_intr_cause;
 
 TEST(Qca7000ResetSimple, ReturnsTrue) {
+    mock_signature = 0xAA55;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = SPI_INT_CPU_ON;
     ASSERT_TRUE(qca7000ResetAndCheck());
+}
+
+TEST(Qca7000ResetSimple, MissingCpuOnHardReset) {
+    mock_signature = 0xAA55;
+    mock_wrbuf = 0x0C5B;
+    mock_intr_cause = 0;
+    testing::internal::CaptureStderr();
+    EXPECT_FALSE(qca7000ResetAndCheck());
+    std::string log = testing::internal::GetCapturedStderr();
+    EXPECT_NE(std::string::npos, log.find("CPU_ON"));
+    mock_intr_cause = SPI_INT_CPU_ON;
+}
+
+TEST(Qca7000ResetSimple, MissingCpuOnSoftReset) {
+    mock_intr_cause = 0;
+    testing::internal::CaptureStderr();
+    EXPECT_FALSE(qca7000SoftReset());
+    std::string log = testing::internal::GetCapturedStderr();
+    EXPECT_NE(std::string::npos, log.find("CPU_ON"));
+    mock_intr_cause = SPI_INT_CPU_ON;
 }


### PR DESCRIPTION
## Summary
- fail hard and soft resets if CPU_ON bit never appears
- propagate reset failures to error handlers
- cover CPU_ON failures in unit tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68924a4f44388324a3b6b7784b0ef7aa