### PR TITLE
Add configurable pins for QCA7000 interface

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
@@ -165,11 +165,13 @@ const uint8_t* qca7000GetNmk() {
 spi_device_handle_t g_spi = nullptr;
 int g_cs = -1;
 int g_rst = PLC_SPI_RST_PIN;
+int g_int = PLC_INT_PIN;
 int g_pwr = PLC_PWR_EN_PIN;
 #else
 static spi_device_handle_t g_spi = nullptr;
 static int g_cs = -1;
 static int g_rst = PLC_SPI_RST_PIN;
+static int g_int = PLC_INT_PIN;
 static int g_pwr = PLC_PWR_EN_PIN;
 #endif
 static inline int setSlow() { return slac::spi_slow_hz(); }
@@ -1313,8 +1315,18 @@ void qca7000Process() {
     qca7000ProcessSlice(500);
 }
 
-bool qca7000setup(spi_device_handle_t bus, int csPin, int rstPin) {
-    ESP_LOGI(PLC_TAG, "QCA7000 setup: bus=%p CS=%d RST=%d", bus, csPin, rstPin);
+bool qca7000setup(spi_device_handle_t bus,
+                  int csPin,
+                  int rstPin,
+                  int intPin,
+                  int pwrPin) {
+    ESP_LOGI(PLC_TAG,
+             "QCA7000 setup: bus=%p CS=%d RST=%d INT=%d PWR=%d",
+             bus,
+             csPin,
+             rstPin,
+             intPin,
+             pwrPin);
     if (!ring) {
         ring = new (std::nothrow) RxEntry[RING_SIZE];
         head.store(0, std::memory_order_relaxed);
@@ -1323,7 +1335,8 @@ bool qca7000setup(spi_device_handle_t bus, int csPin, int rstPin) {
     g_spi = bus;
     g_cs = csPin;
     g_rst = rstPin;
-    g_pwr = PLC_PWR_EN_PIN;
+    g_int = intPin;
+    g_pwr = pwrPin;
     gpio_set_direction(static_cast<gpio_num_t>(g_cs), GPIO_MODE_OUTPUT);
     gpio_set_level(static_cast<gpio_num_t>(g_cs), 1);
     if (g_pwr >= 0) {

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
@@ -74,11 +74,16 @@ struct qca7000_config {
     spi_device_handle_t spi;
     int cs_pin;
     int rst_pin{PLC_SPI_RST_PIN};
+    int int_pin{PLC_INT_PIN};
+    int pwr_en_pin{PLC_PWR_EN_PIN};
     const uint8_t* mac_addr{nullptr};
 };
 
-bool qca7000setup(spi_device_handle_t spi, int cs_pin,
-                  int rst_pin = PLC_SPI_RST_PIN);
+bool qca7000setup(spi_device_handle_t spi,
+                  int cs_pin,
+                  int rst_pin = PLC_SPI_RST_PIN,
+                  int int_pin = PLC_INT_PIN,
+                  int pwr_en_pin = PLC_PWR_EN_PIN);
 void qca7000teardown();
 bool qca7000ResetAndCheck();
 bool qca7000SoftReset();

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
@@ -41,13 +41,15 @@ bool Qca7000Link::open() {
     spi_device_handle_t bus = cfg.spi;
     int cs = cfg.cs_pin ? cfg.cs_pin : PLC_SPI_CS_PIN;
     int rst = cfg.rst_pin ? cfg.rst_pin : PLC_SPI_RST_PIN;
+    int intr = cfg.int_pin ? cfg.int_pin : PLC_INT_PIN;
+    int pwr = cfg.pwr_en_pin ? cfg.pwr_en_pin : PLC_PWR_EN_PIN;
 
     if (ETH_FRAME_LEN > V2GTP_BUFFER_SIZE || !bus) {
         initialization_error = true;
         return false;
     }
 
-    if (!qca7000setup(bus, cs, rst)) {
+    if (!qca7000setup(bus, cs, rst, intr, pwr)) {
         initialization_error = true;
         return false;
     }

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -138,7 +138,8 @@ extern "C" void app_main(void) {
     spi_device_handle_t spi_handle;
     ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &devcfg, &spi_handle));
 
-    qca7000_config cfg{spi_handle, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN, g_mac_addr};
+    qca7000_config cfg{spi_handle, PLC_SPI_CS_PIN, PLC_SPI_RST_PIN,
+                       PLC_INT_PIN, PLC_PWR_EN_PIN, g_mac_addr};
     static slac::port::Qca7000Link link(cfg);
     link.set_error_callback([](Qca7000ErrorStatus, void*) {
         ESP_LOGI(TAG, "[PLC] Fatal error - driver auto-reset");

--- a/examples/platformio_complete/test/test_custom_pins.cpp
+++ b/examples/platformio_complete/test/test_custom_pins.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "qca7000_link.hpp"
+#include "qca7000.hpp"
+
+static spi_device_handle_t last_spi = nullptr;
+static int last_cs = -1;
+static int last_rst = -1;
+static int last_int = -1;
+static int last_pwr = -1;
+
+bool qca7000setup(spi_device_handle_t spi,
+                  int cs,
+                  int rst,
+                  int intr,
+                  int pwr) {
+    last_spi = spi;
+    last_cs = cs;
+    last_rst = rst;
+    last_int = intr;
+    last_pwr = pwr;
+    return true;
+}
+
+void qca7000teardown() {}
+
+void qca7000SetMac(const uint8_t*) {}
+void qca7000SetErrorCallback(qca7000_error_cb_t, void*, bool*) {}
+bool spiQCA7000SendEthFrame(const uint8_t*, size_t) { return true; }
+size_t spiQCA7000checkForReceivedData(uint8_t*, size_t) { return 0; }
+
+TEST(Qca7000Pins, CustomValuesForwarded) {
+    spi_device_handle_t spi = reinterpret_cast<spi_device_handle_t>(0x1);
+    qca7000_config cfg{spi, 2, 3, 4, 5, nullptr};
+    slac::port::Qca7000Link link(cfg);
+    ASSERT_TRUE(link.open());
+    EXPECT_EQ(last_int, 4);
+    EXPECT_EQ(last_pwr, 5);
+}

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -26,6 +26,8 @@ bool qca7000CheckBcbToggle();
 spi_device_handle_t spi_used = nullptr;
 int spi_cs = -1;
 int spi_rst = -1;
+int spi_int = -1;
+int spi_pwr = -1;
 
 bool reset_called = false;
 bool soft_reset_called = false;
@@ -74,8 +76,17 @@ extern "C" void mock_spi_feed_raw(const uint8_t* d, size_t l) {
     soft_reset_called = false;
 }
 
-bool qca7000setup(spi_device_handle_t spi, int cs, int rst) {
-    spi_used = spi; spi_cs = cs; spi_rst = rst; return true;
+bool qca7000setup(spi_device_handle_t spi,
+                  int cs,
+                  int rst,
+                  int intr,
+                  int pwr) {
+    spi_used = spi;
+    spi_cs = cs;
+    spi_rst = rst;
+    spi_int = intr;
+    spi_pwr = pwr;
+    return true;
 }
 
 void qca7000teardown() { spi_used = nullptr; }


### PR DESCRIPTION
## Summary
- allow configuring QCA7000 interrupt and power enable pins
- forward pin configuration through Qca7000Link and example main
- add integration test for custom pin handling

## Testing
- `./run_tests.sh`
- `g++ ... test_custom_pins.cpp ... && /tmp/test_custom_pins`

------
https://chatgpt.com/codex/tasks/task_e_68925925f0588324b1b47cb397b4eefc