### PR TITLE
docs: document PLC pin overrides

### DIFF
--- a/docs/BoardExample.md
+++ b/docs/BoardExample.md
@@ -7,6 +7,29 @@ default) so the driver can react to modem events. QCA7005-based PLC
 Stamp micro modules are fully compatible and can be wired in the same
 way.
 
+## Pin mapping
+
+The ESP32‑S3 port defines default pins via compile‑time macros that can
+be overridden to suit your wiring. All signals use 3.3 V logic levels.
+
+| Signal        | Macro                | Default | Notes |
+|---------------|----------------------|---------|-------|
+| SPI SCK       | `PLC_SPI_SCK_PIN`    | 48      | push‑pull output, no pull‑ups required |
+| SPI MISO      | `PLC_SPI_MISO_PIN`   | 21      | driven by modem, tri‑stated when idle; no pull‑up needed |
+| SPI MOSI      | `PLC_SPI_MOSI_PIN`   | 47      | push‑pull output, no pull‑ups required |
+| Chip Select   | `PLC_SPI_CS_PIN`     | 41      | keep high when idle; optional pull‑up |
+| Reset         | `PLC_SPI_RST_PIN`    | 40      | active low; tie high with resistor if GPIO is high‑Z at boot |
+| Interrupt     | `PLC_INT_PIN`        | 16      | active‑low open‑drain; requires pull‑up (e.g. 10 kΩ) |
+| Power Enable  | `PLC_PWR_EN_PIN`     | 15      | active high; keep low with pull‑down so modem stays off at reset |
+
+If your hardware provides external resistors the internal ones of the
+ESP32 can be disabled. Otherwise configure them appropriately with
+`pinMode`.
+
+Override these defaults by defining the macros in your source before
+including `qca7000.hpp` or by adding `-D` flags in `platformio.ini` as
+shown below.
+
 ## PlatformIO configuration
 
 ```ini
@@ -20,8 +43,13 @@ board_build.partitions = default_8MB.csv
 board_upload.flash_size = 8MB
 board_build.arduino.memory_type = dio_qspi
 build_flags = \
+    -DPLC_SPI_SCK_PIN=48 \
+    -DPLC_SPI_MISO_PIN=21 \
+    -DPLC_SPI_MOSI_PIN=47 \
     -DPLC_SPI_CS_PIN=41 \
     -DPLC_SPI_RST_PIN=40 \
+    -DPLC_INT_PIN=16 \
+    -DPLC_PWR_EN_PIN=15 \
     -DPLC_SPI_SLOW_HZ=500000
 ```
 

--- a/docs/PlatformIOExample.md
+++ b/docs/PlatformIOExample.md
@@ -66,6 +66,24 @@ PlatformIO downloads the library and sets up include paths
 automatically.  This keeps the example self contained without copying
 the sources into your project.
 
+Individual pin assignments can be overridden in the same section using
+`-D` flags.  For example:
+
+```ini
+build_flags = \
+    -std=gnu++17 -DESP_PLATFORM \
+    -DPLC_SPI_SCK_PIN=48 \
+    -DPLC_SPI_MISO_PIN=21 \
+    -DPLC_SPI_MOSI_PIN=47 \
+    -DPLC_SPI_CS_PIN=41 \
+    -DPLC_SPI_RST_PIN=40 \
+    -DPLC_INT_PIN=16 \
+    -DPLC_PWR_EN_PIN=15
+```
+
+These macros may also be defined directly in source files before
+including `qca7000.hpp` if you prefer not to modify `platformio.ini`.
+
 ## 5. Example `main.cpp`
 
 The example firmware simply initialises the QCA7000 link and polls the

--- a/docs/qca7000-bring-up.md
+++ b/docs/qca7000-bring-up.md
@@ -4,17 +4,42 @@ This short guide covers basic wiring and verification of a QCA7000-based power l
 
 ## Pin Configuration
 
-The ESP32-S3 port defines default SPI pins in `port/esp32s3/qca7000.hpp`:
+The ESP32‑S3 port defines default pin assignments via compile‑time
+macros in `port/esp32s3/qca7000.hpp`:
 
 | Signal        | Macro                | Default Pin |
-|---------------|---------------------|-------------|
-| SPI MISO      | `PLC_SPI_MISO_PIN`  | 21          |
-| SPI MOSI      | `PLC_SPI_MOSI_PIN`  | 47          |
-| SPI SCK       | `PLC_SPI_SCK_PIN`   | 48          |
-| Chip Select   | `PLC_SPI_CS_PIN`    | 17          |
-| Reset         | `PLC_SPI_RST_PIN`   | 5           |
+|---------------|----------------------|-------------|
+| SPI MISO      | `PLC_SPI_MISO_PIN`   | 21          |
+| SPI MOSI      | `PLC_SPI_MOSI_PIN`   | 47          |
+| SPI SCK       | `PLC_SPI_SCK_PIN`    | 48          |
+| Chip Select   | `PLC_SPI_CS_PIN`     | 17          |
+| Reset         | `PLC_SPI_RST_PIN`    | 5           |
+| Interrupt¹    | `PLC_INT_PIN`        | —           |
+| Power Enable² | `PLC_PWR_EN_PIN`     | —           |
 
-Override these macros or pass explicit values to `qca7000_config` if your wiring differs. The interrupt line is defined by `PLC_INT_PIN` (IO16 in the example configuration) and should be connected so an ISR can call `qca7000ProcessSlice()` when the modem signals new data.
+1. Active‑low open‑drain; add a pull‑up to 3.3 V (10 kΩ typical).
+2. Optional active‑high control; keep low with a pull‑down resistor when
+   unused.
+
+The SPI signals are push‑pull and normally do not require additional
+pull‑ups or pull‑downs.
+
+Override these macros or pass explicit values to `qca7000_config` if your
+wiring differs. For example, in `platformio.ini`:
+
+```ini
+build_flags = \
+    -DPLC_SPI_SCK_PIN=48 \
+    -DPLC_SPI_MISO_PIN=21 \
+    -DPLC_SPI_MOSI_PIN=47 \
+    -DPLC_SPI_CS_PIN=41 \
+    -DPLC_SPI_RST_PIN=40 \
+    -DPLC_INT_PIN=16 \
+    -DPLC_PWR_EN_PIN=15
+```
+
+The interrupt line should be connected so an ISR can call
+`qca7000ProcessSlice()` when the modem signals new data.
 
 ```cpp
 volatile bool plc_irq = false;


### PR DESCRIPTION
## Summary
- describe default SPI, interrupt and power enable pins
- show how to override PLC pin macros in `platformio.ini`
- note required pull-ups or pull-downs for each signal

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689260c392fc83248d41b295ba8d20e6