### PR TITLE
Fix PlatformIO build configuration

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,3 +1,9 @@
 extern "C" void app_main(void) {
     // Placeholder entry point for ESP-IDF builds
 }
+
+int main() {
+    // Call the ESP-IDF entry when building natively
+    app_main();
+    return 0;
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,7 +1,8 @@
 [platformio]
 src_dir = main
 
-[env]
+[env:native]
+platform = native
 build_flags =
     -std=gnu++17
     -Iinclude


### PR DESCRIPTION
## Summary
- define a named native environment in `platformio.ini`
- add a simple `main` stub for desktop builds

## Testing
- `./run_tests.sh`
- `pio run`
- `cd examples/platformio_complete && pio run`

------
https://chatgpt.com/codex/tasks/task_e_68927f711bcc83249bd27d2816a267e2