### PR TITLE
Add native PlatformIO build target

### DIFF
--- a/examples/platformio_complete/.gitignore
+++ b/examples/platformio_complete/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+sdkconfig.esp32s3

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1,3 +1,9 @@
+#ifdef ESP_PLATFORM
 extern "C" void app_main(void) {
     // Placeholder entry point for ESP-IDF builds
 }
+#else
+int main() {
+    return 0;
+}
+#endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,3 +16,6 @@ build_flags =
     -Wno-error=unused-value
 
 lib_ldf_mode = chain
+
+[env:native]
+platform = native


### PR DESCRIPTION
## Summary
- add native PlatformIO environment to allow local builds
- provide a minimal `main()` when building without ESP-IDF
- ignore generated `sdkconfig.esp32s3` file in example project

## Testing
- `pio run`
- `pio run -d examples/platformio_complete -e esp32s3`
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68927f711bcc83249bd27d2816a267e2