### PR TITLE
Allow optional 5% clamping for CP PWM duty

### DIFF
--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -48,7 +48,7 @@ void cpPwmInit() {
     cpPwmStop();
 }
 
-void cpPwmStart(uint16_t duty_raw) {
+void cpPwmStart(uint16_t duty_raw, bool clamp) {
 #ifdef ESP_PLATFORM
     if (cp_pm_lock)
         esp_pm_lock_acquire(cp_pm_lock);
@@ -56,7 +56,8 @@ void cpPwmStart(uint16_t duty_raw) {
     const uint16_t max_duty = (1u << CP_PWM_RES_BITS) - 1;
     if (duty_raw > max_duty)
         duty_raw = max_duty;
-    duty_raw = clamp_5pct(duty_raw);
+    if (clamp)
+        duty_raw = clamp_5pct(duty_raw);
     if (pinWasInput) {
         gpio_set_direction(static_cast<gpio_num_t>(CP_PWM_OUT_PIN), GPIO_MODE_OUTPUT);
         pinWasInput = false;
@@ -67,14 +68,15 @@ void cpPwmStart(uint16_t duty_raw) {
     pwmRunning = true;
 }
 
-void cpPwmSetDuty(uint16_t duty_raw) {
+void cpPwmSetDuty(uint16_t duty_raw, bool clamp) {
     if (!pwmRunning)
-        cpPwmStart(duty_raw);
+        cpPwmStart(duty_raw, clamp);
     else {
         const uint16_t max_duty = (1u << CP_PWM_RES_BITS) - 1;
         if (duty_raw > max_duty)
             duty_raw = max_duty;
-        duty_raw = clamp_5pct(duty_raw);
+        if (clamp)
+            duty_raw = clamp_5pct(duty_raw);
         ledc_set_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(PWM_CHANNEL), duty_raw);
         ledc_update_duty(LEDC_LOW_SPEED_MODE, static_cast<ledc_channel_t>(PWM_CHANNEL));
         cpSetLastPwmDuty(duty_raw);

--- a/examples/platformio_complete/src/cp_pwm.h
+++ b/examples/platformio_complete/src/cp_pwm.h
@@ -3,7 +3,12 @@
 #include "cp_config.h"
 
 void cpPwmInit();
-void cpPwmStart(uint16_t duty_raw = CP_PWM_DUTY_5PCT);
+// Start CP PWM output. If `clamp_5pct` is true the duty cycle will be
+// constrained to the 4.5–5.5%% window used during the PWM handshake.
+// Otherwise the raw duty value is used allowing the full 0–100%% range.
+void cpPwmStart(uint16_t duty_raw = CP_PWM_DUTY_5PCT, bool clamp_5pct = false);
 void cpPwmStop();
-void cpPwmSetDuty(uint16_t duty_raw);
+// Update the CP PWM duty cycle. Behaviour is identical to cpPwmStart with
+// respect to the `clamp_5pct` flag.
+void cpPwmSetDuty(uint16_t duty_raw, bool clamp_5pct = false);
 bool cpPwmIsRunning();

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -56,7 +56,8 @@ static void handleIdleA() {
     }
     CpSubState s = cpGetSubState();
     if (s == CP_B1 || s == CP_B3) {
-        cpPwmStart(CP_PWM_DUTY_5PCT);
+        // Apply 5% clamping during the initial handshake
+        cpPwmStart(CP_PWM_DUTY_5PCT, true);
         stageEnter(EVSE_INITIALISE_B1);
     }
 }
@@ -143,9 +144,10 @@ static void handlePowerDown() {
 
 static void handleUnlockB1() {
     if (t_stage.load(std::memory_order_relaxed) == 0 || !cpPwmIsRunning()) {
-        cpPwmStart(CP_PWM_DUTY_5PCT); // hold 9V while waiting for unplug
+        // Keep the pilot at 9V while waiting for unplug
+        cpPwmStart(CP_PWM_DUTY_5PCT, true); // clamp as required during handshake
     } else {
-        cpPwmSetDuty(CP_PWM_DUTY_5PCT);
+        cpPwmSetDuty(CP_PWM_DUTY_5PCT, true);
     }
     if (cpGetSubState() == CP_A) {
         stageEnter(EVSE_IDLE_A);

--- a/tests/test_cp_pwm.cpp
+++ b/tests/test_cp_pwm.cpp
@@ -16,7 +16,7 @@ uint32_t g_ledc_last_duty;
 TEST(CpPwm, ResumesAfterStopWhenIdleDriveLow) {
     // Initialize and start PWM
     cpPwmInit();
-    cpPwmStart(CP_PWM_DUTY_5PCT);
+    cpPwmStart(CP_PWM_DUTY_5PCT, true);
     cpPwmStop();
 
     // Clear tracking variables
@@ -25,10 +25,26 @@ TEST(CpPwm, ResumesAfterStopWhenIdleDriveLow) {
     g_ledc_last_duty = 0;
 
     // Restart PWM
-    cpPwmStart(CP_PWM_DUTY_5PCT);
+    cpPwmStart(CP_PWM_DUTY_5PCT, true);
 
     EXPECT_TRUE(cpPwmIsRunning());
     EXPECT_EQ(g_last_gpio_mode, GPIO_MODE_OUTPUT);
     EXPECT_EQ(g_gpio_mode_at_ledc_set_duty, GPIO_MODE_OUTPUT);
     EXPECT_EQ(g_ledc_last_duty, CP_PWM_DUTY_5PCT);
+}
+
+TEST(CpPwm, AcceptsDutyOutsideFivePercent) {
+    cpPwmInit();
+
+    // Set duty below the 5% handshake window without clamping
+    uint16_t duty_low = CP_PWM_DUTY_5PCT / 2;
+    cpPwmSetDuty(duty_low, false);
+    EXPECT_EQ(g_ledc_last_duty, duty_low);
+    EXPECT_EQ(cpGetLastPwmDuty(), duty_low);
+
+    // Set duty above the handshake window without clamping
+    uint16_t duty_high = CP_PWM_DUTY_5PCT * 2;
+    cpPwmSetDuty(duty_high, false);
+    EXPECT_EQ(g_ledc_last_duty, duty_high);
+    EXPECT_EQ(cpGetLastPwmDuty(), duty_high);
 }

--- a/tests/test_cp_state_machine.cpp
+++ b/tests/test_cp_state_machine.cpp
@@ -31,9 +31,9 @@ static bool pwm_running = false;
 static int pwm_start_calls = 0;
 static int pwm_set_calls = 0;
 
-void cpPwmStartStub(uint16_t) { pwm_running = true; ++pwm_start_calls; }
+void cpPwmStartStub(uint16_t, bool) { pwm_running = true; ++pwm_start_calls; }
 void cpPwmStopStub() { pwm_running = false; }
-void cpPwmSetDutyStub(uint16_t) { ++pwm_set_calls; }
+void cpPwmSetDutyStub(uint16_t, bool) { ++pwm_set_calls; }
 bool cpPwmIsRunningStub() { return pwm_running; }
 
 CpSubState g_cp_substate = CP_A;


### PR DESCRIPTION
## Summary
- Parameterize CP PWM so 5% handshake clamping can be enabled or disabled
- Pass clamping flag from the EVSE state machine during handshake
- Test that arbitrary PWM duties propagate via cpGetLastPwmDuty

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894df7168608324a68bd80af9ddae71