### PR TITLE
Measure CP duty from ADC samples

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -14,6 +14,7 @@ char     cpGetStateLetter();
 
 void     cpSetLastPwmDuty(uint16_t duty);
 uint16_t cpGetLastPwmDuty();
+uint16_t cpGetMeasuredDuty();
 
 bool     cpDigitalCommRequested();
 

--- a/tests/test_cp_monitor.cpp
+++ b/tests/test_cp_monitor.cpp
@@ -63,3 +63,99 @@ TEST(CpMonitor, VoutMeasurement) {
     uint16_t expected_mv = static_cast<uint16_t>(((1000u + 3000u) / 2u * 3300) / 4095);
     EXPECT_EQ(voutGetVoltageMv(), expected_mv);
 }
+
+static void init_monitor() {
+    adc_digi_output_data_t initbuf[1] = {};
+    initbuf[0].type1.channel = CP_CH;
+    initbuf[0].type1.data = 0;
+    adcMockSetDmaData(initbuf, 1);
+    cpMonitorInit();
+}
+
+static void feed_and_process(const adc_digi_output_data_t* buf, size_t count, int times = 3) {
+    for (int i = 0; i < times; ++i) {
+        adcMockSetDmaData(buf, count);
+        cpMonitorTestProcess();
+    }
+}
+
+TEST(CpMonitor, DutyClassificationB1) {
+    reset_mocks();
+    init_monitor();
+
+    adc_digi_output_data_t buf[20] = {};
+    for (int i = 0; i < 20; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = 2800; // >9V but <12V
+    }
+    feed_and_process(buf, 20);
+
+    EXPECT_EQ(cpGetMeasuredDuty(), 0);
+    EXPECT_EQ(cpGetSubState(), CP_B1);
+
+    cpMonitorStop();
+}
+
+TEST(CpMonitor, DutyClassificationB3) {
+    reset_mocks();
+    init_monitor();
+
+    adc_digi_output_data_t buf[20] = {};
+    for (int i = 0; i < 10; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = 2800;
+    }
+    for (int i = 10; i < 20; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = 0;
+    }
+    feed_and_process(buf, 20);
+
+    uint16_t expected = static_cast<uint16_t>((10u << CP_PWM_RES_BITS) / 20u);
+    EXPECT_EQ(cpGetMeasuredDuty(), expected);
+    EXPECT_EQ(cpGetSubState(), CP_B3);
+
+    cpMonitorStop();
+}
+
+TEST(CpMonitor, DutyClassificationB2) {
+    reset_mocks();
+    init_monitor();
+
+    adc_digi_output_data_t buf[20] = {};
+    buf[0].type1.channel = CP_CH;
+    buf[0].type1.data = 2233; // peak ~8V
+    for (int i = 1; i < 20; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = (i == 1) ? 0 : 2233; // one low sample
+    }
+    feed_and_process(buf, 20);
+
+    uint16_t expected = static_cast<uint16_t>((1u << CP_PWM_RES_BITS) / 20u);
+    EXPECT_EQ(cpGetMeasuredDuty(), expected);
+    EXPECT_EQ(cpGetSubState(), CP_B2);
+
+    cpMonitorStop();
+}
+
+TEST(CpMonitor, DutyClassificationC) {
+    reset_mocks();
+    init_monitor();
+
+    adc_digi_output_data_t buf[20] = {};
+    for (int i = 0; i < 10; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = 2233; // ~8V
+    }
+    for (int i = 10; i < 20; ++i) {
+        buf[i].type1.channel = CP_CH;
+        buf[i].type1.data = 0;
+    }
+    feed_and_process(buf, 20);
+
+    uint16_t expected = static_cast<uint16_t>((10u << CP_PWM_RES_BITS) / 20u);
+    EXPECT_EQ(cpGetMeasuredDuty(), expected);
+    EXPECT_EQ(cpGetSubState(), CP_C);
+
+    cpMonitorStop();
+}


### PR DESCRIPTION
## Summary
- derive CP low-side duty cycle from ADC samples
- switch state classification to use measured duty
- add `cpGetMeasuredDuty` API for diagnostics
- cover duty-based state transitions with unit tests

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894e746ff28832494505cccbe350dab