### PR TITLE
Track CP min voltage and test E/F transitions

### DIFF
--- a/examples/platformio_complete/src/cp_monitor.h
+++ b/examples/platformio_complete/src/cp_monitor.h
@@ -1,24 +1,33 @@
 #pragma once
-#include <stdint.h>
 #include "cp_config.h"
+#include <stdint.h>
 
-enum CpSubState : uint8_t { CP_A, CP_B1, CP_B2, CP_B3, CP_C, CP_D, CP_E, CP_F };
+enum CpSubState : uint8_t {
+    CP_A,
+    CP_B1,
+    CP_B2,
+    CP_B3,
+    CP_C,
+    CP_D,
+    CP_E,
+    CP_F
+};
 
-void     cpMonitorInit();
-void     cpMonitorStop();
+void cpMonitorInit();
+void cpMonitorStop();
 
 uint16_t cpGetVoltageMv();
+uint16_t cpGetVoltageMinMv();
 uint16_t voutGetVoltageMv();
 CpSubState cpGetSubState();
-char     cpGetStateLetter();
+char cpGetStateLetter();
 
-void     cpSetLastPwmDuty(uint16_t duty);
+void cpSetLastPwmDuty(uint16_t duty);
 uint16_t cpGetLastPwmDuty();
 uint16_t cpGetMeasuredDuty();
 
-bool     cpDigitalCommRequested();
+bool cpDigitalCommRequested();
 
 #ifdef LIBSLAC_TESTING
-void     cpMonitorTestProcess();
+void cpMonitorTestProcess();
 #endif
-


### PR DESCRIPTION
## Summary
- Record both max and min CP voltages and evaluate negative thresholds in `mv2state`
- Expose minimum CP voltage and update sampling to track it
- Add tests for Control Pilot state transitions to and from E and F

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6894eef940008324bf08932ef6be3c09