### PR TITLE
Log connected EV MAC address

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.cpp
@@ -665,6 +665,10 @@ const uint8_t* qca7000GetMac() {
     return g_src_mac;
 }
 
+const uint8_t* qca7000GetMatchedMac() {
+    return g_slac_ctx.matched_mac;
+}
+
 qca7000_region qca7000GetRegion() {
     return g_region;
 }

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
@@ -117,6 +117,8 @@ void qca7000SetNmk(const uint8_t nmk[slac::defs::NMK_LEN]);
 const uint8_t* qca7000GetNmk();
 void qca7000SetMac(const uint8_t mac[ETH_ALEN]);
 const uint8_t* qca7000GetMac();
+/// Returns the MAC address of the matched PEV, or all zeros when none.
+const uint8_t* qca7000GetMatchedMac();
 
 enum class qca7000_region : uint8_t {
     EU = 0x00,

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -112,8 +112,9 @@ void logStatus() {
         static_cast<float>((1u << CP_PWM_RES_BITS) - 1u);
     uint32_t vout_mv = voutGetVoltageMv();
     uint16_t vout_raw = voutGetVoltageRaw();
+    const uint8_t* ev_mac = qca7000GetMatchedMac();
     ESP_LOGI(TAG,
-             "[STAT] CP=%c %lu.%03lu V Duty=%.1f%% Vout=%lu.%03lu V Raw=%u Stage=%s SLAC=%u",
+             "[STAT] CP=%c %lu.%03lu V Duty=%.1f%% Vout=%lu.%03lu V Raw=%u Stage=%s SLAC=%u EV=%02X:%02X:%02X:%02X:%02X:%02X",
              cpGetStateLetter(),
              static_cast<unsigned long>(cp_mv / 1000),
              static_cast<unsigned long>(cp_mv % 1000),
@@ -122,7 +123,8 @@ void logStatus() {
              static_cast<unsigned long>(vout_mv % 1000),
              static_cast<unsigned>(vout_raw),
              evseStageName(evseGetStage()),
-             g_slac_state.load(std::memory_order_relaxed));
+             g_slac_state.load(std::memory_order_relaxed),
+             ev_mac[0], ev_mac[1], ev_mac[2], ev_mac[3], ev_mac[4], ev_mac[5]);
 }
 
 static void logTask(void*) {

--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -286,6 +286,7 @@ void qca7000SetErrorCallback(qca7000_error_cb_t, void*, bool*) {}
 void qca7000SetNmk(const uint8_t[slac::defs::NMK_LEN]) {}
 void qca7000SetMac(const uint8_t[ETH_ALEN]) {}
 const uint8_t* qca7000GetMac() { static uint8_t mac[ETH_ALEN] = {}; return mac; }
+const uint8_t* qca7000GetMatchedMac() { return matched_mac; }
 static bool sleeping = false;
 bool wake_called = false;
 bool mock_bcb_toggle = false;


### PR DESCRIPTION
## Summary
- expose matched PEV MAC via `qca7000GetMatchedMac`
- include EV MAC in status logs so connected EVs are identifiable
- extend test HAL mock for matched MAC retrieval

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689504b1bf988324a6b3d38c81b4eea9