### PR TITLE
Use SlacState enum for SLAC state tracking

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
@@ -13,6 +13,7 @@ using gpio_num_t = int;
 #endif
 #include <slac/channel.hpp>
 #include <slac/slac.hpp>
+#include <slac/slac_states.hpp>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -100,7 +101,7 @@ bool qca7000CheckAlive();
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t maxLen);
 bool spiQCA7000SendEthFrame(const uint8_t* frame, size_t len);
 bool qca7000startSlac();
-uint8_t qca7000getSlacResult();
+SlacState qca7000getSlacResult();
 void qca7000ToggleCpEf();
 // Poll the modem for events and service the RX ring.
 // If a CPU_ON or buffer error interrupt is detected the driver

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -101,7 +101,7 @@ static void handleDigitalReqB2() {
         stageEnter(EVSE_POWER_DOWN);
         return;
     }
-    if (g_slac_state.load(std::memory_order_relaxed) == 6 &&
+    if (g_slac_state.load(std::memory_order_relaxed) == SlacState::Matched &&
         (ss == CP_C || ss == CP_D)) {
         if (g_use_random_mac && !nmk_switched) {
             uint8_t nmk[slac::defs::NMK_LEN];
@@ -114,7 +114,7 @@ static void handleDigitalReqB2() {
         return;
     }
     if (t_stage.load(std::memory_order_relaxed) > T_HLC_EST_MS &&
-        g_slac_state.load(std::memory_order_relaxed) != 6) {
+        g_slac_state.load(std::memory_order_relaxed) != SlacState::Matched) {
         stageEnter(EVSE_INITIALISE_B1);
     }
 }

--- a/examples/platformio_complete/src/cp_state_machine.h
+++ b/examples/platformio_complete/src/cp_state_machine.h
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <atomic>
 #include <slac/ethernet_defs.hpp>
+#include <slac/slac_states.hpp>
 #include "cp_monitor.h"
 
 enum EvseStage : uint8_t {
@@ -20,7 +21,7 @@ void evseStateMachineTask(void*);
 EvseStage evseGetStage();
 const char* evseStageName(EvseStage);
 
-extern std::atomic<uint8_t> g_slac_state;
+extern std::atomic<SlacState> g_slac_state;
 extern std::atomic<uint32_t> g_slac_ts;
 extern bool g_use_random_mac;
 extern uint8_t g_mac_addr[ETH_ALEN];

--- a/include/slac/slac_states.hpp
+++ b/include/slac/slac_states.hpp
@@ -1,0 +1,17 @@
+#ifndef SLAC_SLAC_STATES_HPP
+#define SLAC_SLAC_STATES_HPP
+
+#include <cstdint>
+
+enum class SlacState : uint8_t {
+    Idle = 0,
+    WaitParmCnf = 1,
+    Sounding = 2,
+    WaitSetKey = 3,
+    WaitValidate = 4,
+    WaitMatch = 5,
+    Matched = 6,
+    Failed = 0xFF,
+};
+
+#endif // SLAC_SLAC_STATES_HPP

--- a/tests/test_cp_state_machine.cpp
+++ b/tests/test_cp_state_machine.cpp
@@ -57,7 +57,7 @@ void vTaskDelay(int) {}
 bool g_use_random_mac = false;
 uint8_t g_mac_addr[ETH_ALEN] = {};
 std::atomic<uint32_t> g_slac_ts{0};
-std::atomic<uint8_t> g_slac_state{0};
+std::atomic<SlacState> g_slac_state{SlacState::Idle};
 
 #include "../examples/platformio_complete/src/cp_state_machine.cpp"
 
@@ -115,7 +115,7 @@ TEST(EvseStateMachine, DigitalReqB2Unplug) {
 
 TEST(EvseStateMachine, DigitalReqB2AdvanceAndFault) {
     // Successful advance to CableCheckC
-    g_slac_state.store(6, std::memory_order_relaxed);
+    g_slac_state.store(SlacState::Matched, std::memory_order_relaxed);
     g_cp_substate = CP_C;
     stageEnter(EVSE_DIGITAL_REQ_B2);
     handleDigitalReqB2();
@@ -129,7 +129,7 @@ TEST(EvseStateMachine, DigitalReqB2AdvanceAndFault) {
 
     // Timeout back to InitialiseB1
     g_cp_substate = CP_D;
-    g_slac_state.store(0, std::memory_order_relaxed);
+    g_slac_state.store(SlacState::Idle, std::memory_order_relaxed);
     stageEnter(EVSE_DIGITAL_REQ_B2);
     t_stage.store(T_HLC_EST_MS + 1, std::memory_order_relaxed);
     handleDigitalReqB2();

--- a/tests/test_log_task.cpp
+++ b/tests/test_log_task.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <atomic>
+#include <slac/slac_states.hpp>
 #define LIBSLAC_TESTING
 #include "esp_log.h"
 #undef ESP_LOGI
@@ -26,10 +27,10 @@ int evseGetStage_stub() { return 0; }
 
 #include "../examples/platformio_complete/src/main.cpp"
 #undef g_slac_state
-extern std::atomic<uint8_t> g_slac_state_main;
+extern std::atomic<SlacState> g_slac_state_main;
 
 TEST(LogTask, PrintsDutyAndVout) {
-    g_slac_state_main.store(7, std::memory_order_relaxed);
+    g_slac_state_main.store(SlacState::Matched, std::memory_order_relaxed);
     testing::internal::CaptureStdout();
     logStatus();
     std::string out = testing::internal::GetCapturedStdout();

--- a/tests/test_slac_filter.cpp
+++ b/tests/test_slac_filter.cpp
@@ -22,15 +22,15 @@ static void send_frame(uint16_t mmtype, const uint8_t src[ETH_ALEN]) {
 
 static void run_match_sequence(const uint8_t mac[ETH_ALEN]) {
     send_frame(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 2);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Sounding);
     send_frame(slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 3);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitSetKey);
     send_frame(slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 4);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitValidate);
     send_frame(slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 5);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitMatch);
     send_frame(slac::defs::MMTYPE_CM_SLAC_MATCH | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 6);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Matched);
 }
 
 TEST(SlacFilter, IgnoreOtherMac) {
@@ -39,10 +39,10 @@ TEST(SlacFilter, IgnoreOtherMac) {
     slac::set_validation_disabled(true);
     mock_ring_reset();
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     run_match_sequence(pev1);
     send_frame(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, pev2);
-    EXPECT_EQ(qca7000getSlacResult(), 6);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Matched);
 }
 
 TEST(SlacFilter, StartClearsFilter) {
@@ -51,10 +51,10 @@ TEST(SlacFilter, StartClearsFilter) {
     slac::set_validation_disabled(true);
     mock_ring_reset();
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     run_match_sequence(pev1);
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     send_frame(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, pev2);
-    EXPECT_EQ(qca7000getSlacResult(), 2);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Sounding);
 }

--- a/tests/test_slac_retry.cpp
+++ b/tests/test_slac_retry.cpp
@@ -12,13 +12,13 @@ TEST(SlacRetry, ParmCnfTimeout) {
     g_mock_millis = 0;
     toggle_count = 0;
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
 
     g_mock_millis += slac::defs::TT_EVSE_SLAC_INIT_MS + 1;
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     EXPECT_EQ(toggle_count, 1);
 
     g_mock_millis += slac::defs::TT_EVSE_SLAC_INIT_MS + 1;
-    EXPECT_EQ(qca7000getSlacResult(), 0xFF);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Failed);
     EXPECT_EQ(toggle_count, 2);
 }

--- a/tests/test_validation.cpp
+++ b/tests/test_validation.cpp
@@ -23,11 +23,11 @@ static void send_frame(uint16_t mmtype, const uint8_t src[ETH_ALEN]) {
 
 static void goto_validate(const uint8_t mac[ETH_ALEN]) {
     send_frame(slac::defs::MMTYPE_CM_SLAC_PARAM | slac::defs::MMTYPE_MODE_CNF, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 2);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Sounding);
     send_frame(slac::defs::MMTYPE_CM_ATTEN_CHAR | slac::defs::MMTYPE_MODE_IND, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 3);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitSetKey);
     send_frame(slac::defs::MMTYPE_CM_SET_KEY | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 4);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitValidate);
 }
 
 TEST(Validation, Success) {
@@ -35,11 +35,11 @@ TEST(Validation, Success) {
     slac::set_validation_disabled(false);
     mock_ring_reset();
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     goto_validate(mac);
     mock_bcb_toggle = true;
     send_frame(slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 5);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitMatch);
 }
 
 TEST(Validation, Failure) {
@@ -47,9 +47,9 @@ TEST(Validation, Failure) {
     slac::set_validation_disabled(false);
     mock_ring_reset();
     ASSERT_TRUE(qca7000startSlac());
-    EXPECT_EQ(qca7000getSlacResult(), 1);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::WaitParmCnf);
     goto_validate(mac);
     mock_bcb_toggle = false;
     send_frame(slac::defs::MMTYPE_CM_VALIDATE | slac::defs::MMTYPE_MODE_REQ, mac);
-    EXPECT_EQ(qca7000getSlacResult(), 0xFF);
+    EXPECT_EQ(qca7000getSlacResult(), SlacState::Failed);
 }


### PR DESCRIPTION
## Summary
- Add shared `SlacState` enum covering SLAC handshake phases and failures
- Replace raw byte state handling with `SlacState` in main example and EVSE state machine
- Update QCA7000 driver and tests to return and compare `SlacState`

## Testing
- `./run_tests.sh` *(fails: build aborted during ESP-IDF compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6895d56a559c832497a3de9c9aa35b23