### PR TITLE
Handle PLC interrupts with FreeRTOS task notification

### DIFF
--- a/tests/freertos/FreeRTOS.h
+++ b/tests/freertos/FreeRTOS.h
@@ -1,7 +1,10 @@
 #pragma once
 #include <stdint.h>
+typedef int BaseType_t;
 #define pdTRUE 1
 #define pdFALSE 0
 #define pdMS_TO_TICKS(ms) (ms)
+#define portMAX_DELAY 0xFFFFFFFFUL
+#define portYIELD_FROM_ISR(...)
 typedef void* TimerHandle_t;
 typedef void (*TimerCallbackFunction_t)(TimerHandle_t);

--- a/tests/freertos/task.h
+++ b/tests/freertos/task.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "FreeRTOS.h"
+typedef void* TaskHandle_t;
 typedef uint32_t TickType_t;
 inline void vTaskDelay(TickType_t) {}
 inline void vTaskDelayUntil(TickType_t*, TickType_t) {}
-inline void xTaskCreatePinnedToCore(void (*)(void*), const char*, uint32_t, void*, uint32_t, void*, int) {}
+inline void xTaskCreatePinnedToCore(void (*)(void*), const char*, uint32_t, void*, uint32_t, TaskHandle_t*, int) {}
+uint32_t ulTaskNotifyTake(BaseType_t, TickType_t);
+void vTaskNotifyGiveFromISR(TaskHandle_t, BaseType_t*);

--- a/tests/test_log_task.cpp
+++ b/tests/test_log_task.cpp
@@ -16,6 +16,11 @@
 #define evseGetStage evseGetStage_stub
 
 #define g_slac_state g_slac_state_main
+#define qca7000ProcessSlice qca7000ProcessSlice_stub
+#define qca7000ReadInternalReg qca7000ReadInternalReg_stub
+
+void qca7000ProcessSlice_stub(uint32_t) {}
+uint16_t qca7000ReadInternalReg_stub(uint16_t) { return 0; }
 
 uint32_t cpGetVoltageMv_stub() { return 0; }
 uint16_t cpGetLastPwmDuty_stub() { return ((1u << CP_PWM_RES_BITS) - 1u) / 2u; }

--- a/tests/test_plc_irq.cpp
+++ b/tests/test_plc_irq.cpp
@@ -1,9 +1,12 @@
 #include <gtest/gtest.h>
 #define GPIO_STUB_CUSTOM
 #include "driver/gpio.h"
+#include "freertos/task.h"
 
 static gpio_config_t last_cfg{};
 static gpio_isr_t registered_isr = nullptr;
+static TaskHandle_t expected_task = nullptr;
+static BaseType_t notified = pdFALSE;
 
 static esp_err_t gpio_config(const gpio_config_t* cfg) {
     last_cfg = *cfg;
@@ -17,54 +20,65 @@ static esp_err_t gpio_isr_handler_add(gpio_num_t, gpio_isr_t isr, void*) {
     return ESP_OK;
 }
 
+uint32_t ulTaskNotifyTake(BaseType_t, TickType_t) { return 0; }
+
+void vTaskNotifyGiveFromISR(TaskHandle_t handle, BaseType_t*) {
+    if (handle == expected_task)
+        notified = pdTRUE;
+}
+
 #define PLC_INT_PIN 0
-#define plc_irq plc_irq_neg
 #define plc_isr plc_isr_neg
 #define plc_irq_setup plc_irq_setup_neg
+#define plc_irq_task_handle plc_irq_task_handle_neg
 #include "examples/platformio_complete/src/plc_irq.hpp"
-#undef plc_irq
 #undef plc_isr
 #undef plc_irq_setup
+#undef plc_irq_task_handle
 
 TEST(PlcIrqEdge, Negative) {
-    plc_irq_neg = false;
-    plc_irq_setup_neg();
+    notified = pdFALSE;
+    TaskHandle_t dummy = reinterpret_cast<TaskHandle_t>(1);
+    expected_task = dummy;
+    plc_irq_setup_neg(dummy);
     EXPECT_EQ(last_cfg.intr_type, GPIO_INTR_NEGEDGE);
     ASSERT_NE(registered_isr, nullptr);
     registered_isr(nullptr);
-    EXPECT_TRUE(plc_irq_neg);
+    EXPECT_TRUE(notified);
 }
 
 #undef PLC_IRQ_HPP
 #undef PLC_INT_EDGE
 #define PLC_INT_EDGE GPIO_INTR_POSEDGE
-#define plc_irq plc_irq_pos
 #define plc_isr plc_isr_pos
 #define plc_irq_setup plc_irq_setup_pos
+#define plc_irq_task_handle plc_irq_task_handle_pos
 #include "examples/platformio_complete/src/plc_irq.hpp"
-#undef plc_irq
 #undef plc_isr
 #undef plc_irq_setup
+#undef plc_irq_task_handle
 
 TEST(PlcIrqEdge, Positive) {
-    plc_irq_pos = false;
-    plc_irq_setup_pos();
+    notified = pdFALSE;
+    TaskHandle_t dummy = reinterpret_cast<TaskHandle_t>(2);
+    expected_task = dummy;
+    plc_irq_setup_pos(dummy);
     EXPECT_EQ(last_cfg.intr_type, GPIO_INTR_POSEDGE);
     ASSERT_NE(registered_isr, nullptr);
     registered_isr(nullptr);
-    EXPECT_TRUE(plc_irq_pos);
+    EXPECT_TRUE(notified);
 }
 
 #undef PLC_INT_PIN
 #define PLC_INT_PIN -1
 
 static bool plc_irq_setup_called = false;
-static void plc_irq_setup_stub() { plc_irq_setup_called = true; }
+static void plc_irq_setup_stub(TaskHandle_t) { plc_irq_setup_called = true; }
 
 TEST(PlcIrqEdge, InvalidPin) {
     testing::internal::CaptureStdout();
     if (PLC_INT_PIN >= 0) {
-        plc_irq_setup_stub();
+        plc_irq_setup_stub(nullptr);
     } else {
         printf("PLC_INT_PIN invalid: %d\n", PLC_INT_PIN);
     }
@@ -72,3 +86,4 @@ TEST(PlcIrqEdge, InvalidPin) {
     EXPECT_FALSE(plc_irq_setup_called);
     EXPECT_NE(log.find("PLC_INT_PIN invalid"), std::string::npos);
 }
+


### PR DESCRIPTION
## Summary
- replace global `plc_irq` flag with FreeRTOS task notification and minimal ISR
- add dedicated `qca7000_irq_task` that drains SPI buffer using `qca7000ProcessSlice`
- update tests and FreeRTOS stubs for notification-based IRQ handling

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_689629d5066c8324a1fb2bd884bf5964