### PR TITLE
Add SLAC init timeout

### DIFF
--- a/examples/platformio_complete/src/cp_state_machine.h
+++ b/examples/platformio_complete/src/cp_state_machine.h
@@ -23,5 +23,7 @@ const char* evseStageName(EvseStage);
 
 extern std::atomic<SlacState> g_slac_state;
 extern std::atomic<uint32_t> g_slac_ts;
+extern std::atomic<uint32_t> g_slac_init_ts;
+extern std::atomic<bool> g_waiting_for_parm_req;
 extern bool g_use_random_mac;
 extern uint8_t g_mac_addr[ETH_ALEN];

--- a/tests/test_cp_state_machine.cpp
+++ b/tests/test_cp_state_machine.cpp
@@ -57,6 +57,8 @@ void vTaskDelay(int) {}
 bool g_use_random_mac = false;
 uint8_t g_mac_addr[ETH_ALEN] = {};
 std::atomic<uint32_t> g_slac_ts{0};
+std::atomic<uint32_t> g_slac_init_ts{0};
+std::atomic<bool> g_waiting_for_parm_req{false};
 std::atomic<SlacState> g_slac_state{SlacState::Idle};
 
 #include "../examples/platformio_complete/src/cp_state_machine.cpp"


### PR DESCRIPTION
## Summary
- start SLAC initialization timer and abort if CM_SLAC_PARM.REQ isn't received
- expose new timer variables to EVSE state machine

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68962e164e508324af61f487d9b974d6