### PR TITLE
Handle CM_VALIDATE.REQ failure

### DIFF
--- a/include/slac/fsm.hpp
+++ b/include/slac/fsm.hpp
@@ -16,6 +16,7 @@ enum class SlacEvent {
     GotAttenCharInd,
     GotSetKeyReq,
     GotValidateReq,
+    ValidateFailed,
     GotMatchReq,
     Timeout,
     Error


### PR DESCRIPTION
## Summary
- Clear SLAC state and disable filtering when CM_VALIDATE.REQ reports failure
- Add `ValidateFailed` event to FSM to return to Idle on validation failure

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6896333bc15c8324b6446b2b0031ed8b