### PR TITLE
Make UART support optional

### DIFF
--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_uart.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_uart.cpp
@@ -1,3 +1,5 @@
+#ifdef CONFIG_SLAC_USE_UART
+
 #include "qca7000_uart.hpp"
 #include "port_config.hpp"
 #include "qca7000.hpp"
@@ -304,3 +306,5 @@ const uint8_t* Qca7000UartLink::mac() const {
 
 } // namespace port
 } // namespace slac
+
+#endif // CONFIG_SLAC_USE_UART

--- a/examples/platformio_complete/lib/slac_port/library.json
+++ b/examples/platformio_complete/lib/slac_port/library.json
@@ -1,0 +1,11 @@
+{
+    "name": "slac_port",
+    "build": {
+        "includeDir": ".",
+        "srcDir": "esp32s3",
+        "srcFilter": [
+            "+<*.cpp>",
+            "-<qca7000_uart.cpp>"
+        ]
+    }
+}

--- a/examples/platformio_complete/platformio.ini
+++ b/examples/platformio_complete/platformio.ini
@@ -1,5 +1,6 @@
 [platformio]
 src_dir = src
+default_envs = esp32s3
 
 [env:esp32s3]
 platform                    = espressif32@6.8.1
@@ -21,6 +22,7 @@ build_flags =
     -Ilib/slac_port
 
 
+
 ; remove the default -std=gnu++11 flag
 build_unflags = -std=gnu++11
 
@@ -28,4 +30,14 @@ extra_scripts              = pre:pio-build_libcbv2g.py
 
 lib_deps =
     ../../
+    slac_port
 lib_ldf_mode = deep
+
+[env:esp32s3-uart]
+extends = env:esp32s3
+build_flags =
+    ${env:esp32s3.build_flags}
+    -DCONFIG_SLAC_USE_UART
+build_src_filter =
+    +<*>
+    +<../lib/slac_port/esp32s3/qca7000_uart.cpp>


### PR DESCRIPTION
## Summary
- wrap QCA7000 UART implementation with `CONFIG_SLAC_USE_UART`
- exclude UART source from default PlatformIO build and add opt-in UART environment
- add `slac_port` library manifest to keep UART code out unless enabled

## Testing
- `pio run -d examples/platformio_complete -e esp32s3`
- `grep -i qca7000_uart /tmp/pio_build.log`
- `./run_tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_6897b31a1bec8324a0a178ae85b0bd93