### PR TITLE
Remove SPI half-duplex flag

### DIFF
--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -181,7 +181,6 @@ extern "C" void app_main(void) {
     devcfg.mode = 3;
     devcfg.spics_io_num = -1;
     devcfg.queue_size = 3;
-    devcfg.flags = SPI_DEVICE_HALFDUPLEX;
     spi_device_handle_t spi_handle;
     ESP_ERROR_CHECK(spi_bus_add_device(SPI2_HOST, &devcfg, &spi_handle));
 


### PR DESCRIPTION
## Summary
- remove SPI_DEVICE_HALFDUPLEX from example configuration
- rely on full duplex or chip select hold during SPI transfers

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897b90b9cc88324869652f489b85f1e