### PR TITLE
Add CP PWM handshake helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,6 +73,15 @@ Control Pilot Monitoring
 
 The example firmware samples the Control Pilot voltage using the ESP32-S3 ADC in continuous mode with DMA. Samples are collected at 50 kS/s into a ring buffer and a background task selects the peak value for each PWM cycle to update the library's Control Pilot state. This approach removes the timing jitter of one-shot conversions and provides accurate peak detection with minimal CPU load.
 
+Deterministic PWM Handshake
+---------------------------
+
+Before starting the SLAC handshake the Control Pilot should briefly be driven
+at a 5\% duty cycle. Call :func:`cpPwmHandshake()` to clamp the PWM output to
+the required 4.5–5.5\% window using :func:`cpPwmSetDuty`. Waiting for
+``T_PLC_INIT_MS`` (700 ms by default) after invoking this helper ensures that
+the EV and EVSE transition to high level communication at a predictable time.
+
 After changing any of these options run ``platformio run`` to verify that the project still builds correctly.
 
 

--- a/examples/platformio_complete/src/cp_pwm.cpp
+++ b/examples/platformio_complete/src/cp_pwm.cpp
@@ -83,6 +83,10 @@ void cpPwmSetDuty(uint16_t duty_raw, bool clamp) {
     }
 }
 
+void cpPwmHandshake() {
+    cpPwmSetDuty(CP_PWM_DUTY_5PCT, true);
+}
+
 void cpPwmStop() {
     if (CP_IDLE_DRIVE_HIGH) {
         constexpr uint16_t DUTY_FULL = (1u << CP_PWM_RES_BITS) - 1;

--- a/examples/platformio_complete/src/cp_pwm.h
+++ b/examples/platformio_complete/src/cp_pwm.h
@@ -11,4 +11,6 @@ void cpPwmStop();
 // Update the CP PWM duty cycle. Behaviour is identical to cpPwmStart with
 // respect to the `clamp_5pct` flag.
 void cpPwmSetDuty(uint16_t duty_raw, bool clamp_5pct = false);
+// Convenience helper to drive the PWM handshake at 5 % duty
+void cpPwmHandshake();
 bool cpPwmIsRunning();

--- a/examples/platformio_complete/src/cp_state_machine.cpp
+++ b/examples/platformio_complete/src/cp_state_machine.cpp
@@ -82,6 +82,7 @@ static void handleInitialiseB1() {
         if (g_use_random_mac) {
             qca7000SetMac(g_mac_addr);
         }
+        cpPwmHandshake();
         if (!qca7000startSlac()) {
             stageEnter(EVSE_IDLE_A);
             return;

--- a/examples/platformio_complete/src/main.cpp
+++ b/examples/platformio_complete/src/main.cpp
@@ -21,6 +21,7 @@
 #include <freertos/task.h>
 #include "plc_irq.hpp"
 #include "cp_config.h"
+#include "cp_pwm.h"
 
 #ifndef LIBSLAC_TESTING
 // Placeholder stubs for control pilot and EVSE state machine logic that would
@@ -28,6 +29,7 @@
 // be built without the full hardware drivers.
 inline void cpPwmInit() {}
 inline void cpMonitorInit() {}
+inline void cpPwmHandshake() {}
 inline bool cpPwmIsRunning() { return false; }
 inline bool cpDigitalCommRequested() { return false; }
 inline uint32_t cpGetVoltageMv() { return 0; }
@@ -265,6 +267,7 @@ extern "C" void app_main(void) {
             qca7000LeaveAvln();
             if (g_use_random_mac)
                 qca7000SetMac(g_mac_addr);
+            cpPwmHandshake();
             if (qca7000startSlac()) {
                 auto now = get_ms();
                 g_slac_ts.store(now, std::memory_order_relaxed);
@@ -294,6 +297,7 @@ extern "C" void app_main(void) {
                 ESP_LOGI(TAG, "Restarting SLAC handshake");
                 if (g_use_random_mac)
                     qca7000SetMac(g_mac_addr);
+                cpPwmHandshake();
                 if (!qca7000startSlac())
                     ESP_LOGI(TAG, "startSlac failed");
                 auto now = get_ms();

--- a/tests/test_cp_state_machine.cpp
+++ b/tests/test_cp_state_machine.cpp
@@ -9,6 +9,7 @@
 #define cpPwmStart cpPwmStartStub
 #define cpPwmStop cpPwmStopStub
 #define cpPwmSetDuty cpPwmSetDutyStub
+#define cpPwmHandshake cpPwmHandshakeStub
 #define cpPwmIsRunning cpPwmIsRunningStub
 #define cpGetSubState cpGetSubStateStub
 #define voutGetVoltageMv voutGetVoltageMvStub
@@ -37,6 +38,7 @@ static uint16_t vout_mv = 0;
 void cpPwmStartStub(uint16_t, bool) { pwm_running = true; ++pwm_start_calls; }
 void cpPwmStopStub() { pwm_running = false; ++pwm_stop_calls; }
 void cpPwmSetDutyStub(uint16_t, bool) { ++pwm_set_calls; }
+void cpPwmHandshakeStub() { ++pwm_set_calls; }
 bool cpPwmIsRunningStub() { return pwm_running; }
 
 CpSubState g_cp_substate = CP_A;


### PR DESCRIPTION
## Summary
- add `cpPwmHandshake()` helper to drive pilot at 5 % duty
- call handshake helper before launching SLAC to stabilize HLC transition
- document PWM handshake timing in README

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897c2404e8083249f8b8d0fefc6cb06