### PR TITLE
Service QCA7000 modem while waiting for frames

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -208,6 +208,8 @@ Polling Operation
 ``libslac`` does not require the QCA7000 interrupt pin. Calling
 ``qca7000ProcessSlice()`` from an IRQ-driven loop keeps the main thread
 responsive while processing at most 500 µs of modem activity per call.
+``Qca7000Link::read`` also invokes ``qca7000ProcessSlice`` while polling so
+that modem events are serviced even when waiting for new data.
 
 UART Mode
 ---------

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000.hpp
@@ -79,6 +79,8 @@ struct qca7000_config {
     int int_pin{PLC_INT_PIN};
     int pwr_en_pin{PLC_PWR_EN_PIN};
     const uint8_t* mac_addr{nullptr};
+    /// Maximum time in microseconds spent servicing modem events when polling
+    uint32_t process_slice_us{500};
 };
 
 bool qca7000setup(spi_device_handle_t spi,

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.cpp
@@ -4,6 +4,8 @@
 #include "qca7000.hpp"
 #include <cstring>
 
+extern void qca7000ProcessSlice(uint32_t max_us);
+
 namespace slac {
 namespace port {
 
@@ -87,6 +89,10 @@ transport::LinkError Qca7000Link::read(uint8_t* b, size_t l, size_t* out, uint32
         }
         if (timeout_ms == 0)
             break;
+        if (initialized)
+            // Service modem events while waiting for a frame
+            qca7000ProcessSlice(cfg.process_slice_us);
+        // Sleep briefly while polling for data
         slac_delay(1);
     } while (slac_millis() - start < timeout_ms);
     *out = 0;

--- a/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.hpp
+++ b/examples/platformio_complete/lib/slac_port/esp32s3/qca7000_link.hpp
@@ -39,6 +39,7 @@ public:
 
     bool open() override;
     bool write(const uint8_t* b, size_t l, uint32_t timeout_ms) override;
+    /// Poll for a frame and service modem events while waiting
     transport::LinkError read(uint8_t* b, size_t l, size_t* out, uint32_t timeout_ms) override;
     const uint8_t* mac() const override;
 


### PR DESCRIPTION
## Summary
- Poll `qca7000ProcessSlice` from `Qca7000Link::read` to process modem events while awaiting data
- Allow configuring the maximum time spent in a slice via `process_slice_us`
- Document read-side servicing of modem events

## Testing
- `./run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6897e74a2ed88324ad6e0cd02b15ba4b