### PR TITLE
Fix test harness compilation issues and ensure example builds

### DIFF
--- a/tests/qca7000_hal_mock.cpp
+++ b/tests/qca7000_hal_mock.cpp
@@ -170,23 +170,24 @@ esp_err_t fetchRx() {
         if (len != frame_total && len + 4 != frame_total) {
             qca7000SoftReset();
             spi_read_len = 0;
-            return;
+            return ESP_OK;
         }
         if (frame_total > remaining) {
             qca7000SoftReset();
             spi_read_len = 0;
-            return;
+            return ESP_OK;
         }
         if (p[RX_HDR + fl] != 0x55 || p[RX_HDR + fl + 1] != 0x55) {
             qca7000SoftReset();
             spi_read_len = 0;
-            return;
+            return ESP_OK;
         }
         mock_receive_frame(p + RX_HDR, fl);
         p += frame_total;
         remaining -= frame_total;
     }
     spi_read_len = 0;
+    return ESP_OK;
 }
 
 size_t spiQCA7000checkForReceivedData(uint8_t* dst, size_t len) {
@@ -271,7 +272,6 @@ static void handle_frame(const uint8_t* d, size_t l) {
         break;
     }
     spi_read_len = 0;
-    return ESP_OK;
 }
 
 SlacState qca7000getSlacResult() {

--- a/tests/test_log_task.cpp
+++ b/tests/test_log_task.cpp
@@ -21,6 +21,11 @@
 
 void qca7000ProcessSlice_stub(uint32_t) {}
 using esp_err_t = int;
+
+#ifndef ESP_OK
+#define ESP_OK 0
+#endif
+
 esp_err_t qca7000ReadInternalReg_stub(uint16_t, uint16_t* out) {
     if (out) *out = 0;
     return ESP_OK;
@@ -33,10 +38,6 @@ uint16_t voutGetVoltageRaw_stub() { return 2048; }
 char cpGetStateLetter_stub() { return 'B'; }
 const char* evseStageName_stub(int) { return "TEST"; }
 int evseGetStage_stub() { return 0; }
-
-#ifndef ESP_OK
-#define ESP_OK 0
-#endif
 
 #include "../examples/platformio_complete/src/main.cpp"
 #undef g_slac_state


### PR DESCRIPTION
## Summary
- Define `ESP_OK` earlier in `test_log_task` and hook stub helper
- Correct `fetchRx` mock to return status codes consistently and drop stray return in `handle_frame`

## Testing
- `./run_tests.sh`
- `platformio run`


------
https://chatgpt.com/codex/tasks/task_e_6899023a0e2483248d5c4112169bbf45